### PR TITLE
empty GET response shouldn't result in 404 for list endpoint

### DIFF
--- a/pkg/api/v1/frontends_get.go
+++ b/pkg/api/v1/frontends_get.go
@@ -5,6 +5,25 @@ import (
 	"go.infratographer.com/load-balancer-api/internal/models"
 )
 
+// frontendList returns a list of frontends
+func (r *Router) frontendList(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	mods, err := r.frontendParamsBinding(c)
+	if err != nil {
+		r.logger.Errorw("failed to bind frontend params", "error", err)
+		return v1BadRequestResponse(c, err)
+	}
+
+	frontends, err := models.Frontends(mods...).All(ctx, r.db)
+	if err != nil {
+		r.logger.Errorw("failed to get frontends", "error", err)
+		return v1InternalServerErrorResponse(c, err)
+	}
+
+	return v1Frontends(c, frontends)
+}
+
 // frontendGet returns a list of frontends for a given load balancer
 func (r *Router) frontendGet(c echo.Context) error {
 	ctx := c.Request().Context()

--- a/pkg/api/v1/frontends_routes.go
+++ b/pkg/api/v1/frontends_routes.go
@@ -4,7 +4,7 @@ import "github.com/labstack/echo/v4"
 
 // addFrontendRoutes adds the frontend routes to the router
 func (r *Router) addFrontendRoutes(rg *echo.Group) {
-	rg.GET("/frontends", r.frontendGet)
+	rg.GET("/frontends", r.frontendList)
 	rg.GET("/frontends/:frontend_id", r.frontendGet)
 	rg.GET("/loadbalancers/:load_balancer_id/frontends", r.frontendGet)
 

--- a/pkg/api/v1/load_balancers_get.go
+++ b/pkg/api/v1/load_balancers_get.go
@@ -5,6 +5,24 @@ import (
 	"go.infratographer.com/load-balancer-api/internal/models"
 )
 
+// loadBalancerList returns a list of load balancers for a tenant
+func (r *Router) loadBalancerList(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	mods, err := r.loadBalancerParamsBinding(c)
+	if err != nil {
+		r.logger.Errorw("failed to bind params", "error", err)
+		return v1BadRequestResponse(c, err)
+	}
+
+	lbs, err := models.LoadBalancers(mods...).All(ctx, r.db)
+	if err != nil {
+		return v1InternalServerErrorResponse(c, err)
+	}
+
+	return v1LoadBalancers(c, lbs)
+}
+
 // loadBalancerGet returns a load balancer for a tenant by ID
 func (r *Router) loadBalancerGet(c echo.Context) error {
 	ctx := c.Request().Context()

--- a/pkg/api/v1/load_balancers_param_binding.go
+++ b/pkg/api/v1/load_balancers_param_binding.go
@@ -33,7 +33,7 @@ func (r *Router) loadBalancerParamsBinding(c echo.Context) ([]qm.QueryMod, error
 	r.logger.Debugw("path param", "tenant_id", tenantID)
 
 	// optional load_balancer_id in the request path
-	if err = ppb.String("load_balancer_id", &tenantID).BindError(); err != nil {
+	if err = ppb.String("load_balancer_id", &loadBalancerID).BindError(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/api/v1/load_balancers_routes.go
+++ b/pkg/api/v1/load_balancers_routes.go
@@ -3,7 +3,7 @@ package api
 import "github.com/labstack/echo/v4"
 
 func (r *Router) addLoadBalancerRoutes(g *echo.Group) {
-	g.GET("/loadbalancers", r.loadBalancerGet)
+	g.GET("/loadbalancers", r.loadBalancerList)
 	g.GET("/loadbalancers/:load_balancer_id", r.loadBalancerGet)
 
 	g.POST("/loadbalancers", r.loadBalancerCreate)

--- a/pkg/api/v1/origins_get.go
+++ b/pkg/api/v1/origins_get.go
@@ -5,7 +5,26 @@ import (
 	"go.infratographer.com/load-balancer-api/internal/models"
 )
 
-// originsGet returns a list of origins
+// originsList returns a list of origins
+func (r *Router) originsList(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	mods, err := r.originsParamsBinding(c)
+	if err != nil {
+		r.logger.Errorw("error parsing query params", "error", err)
+		return v1BadRequestResponse(c, err)
+	}
+
+	os, err := models.Origins(mods...).All(ctx, r.db)
+	if err != nil {
+		r.logger.Errorw("error getting origins", "error", err)
+		return v1InternalServerErrorResponse(c, err)
+	}
+
+	return v1OriginsResponse(c, os)
+}
+
+// originsGet returns an origin by id
 func (r *Router) originsGet(c echo.Context) error {
 	ctx := c.Request().Context()
 

--- a/pkg/api/v1/origins_param_binding.go
+++ b/pkg/api/v1/origins_param_binding.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 
@@ -19,7 +20,12 @@ func (r *Router) originsParamsBinding(c echo.Context) ([]qm.QueryMod, error) {
 
 	originID := c.Param("origin_id")
 	if originID != "" {
+		if _, err := uuid.Parse(originID); err != nil {
+			return nil, ErrInvalidUUID
+		}
+
 		mods = append(mods, models.OriginWhere.OriginID.EQ(originID))
+		r.logger.Debugw("path param", "origin_id", originID)
 	}
 
 	queryParams := []string{"slug", "target", "port"}

--- a/pkg/api/v1/origins_routes.go
+++ b/pkg/api/v1/origins_routes.go
@@ -4,7 +4,7 @@ import "github.com/labstack/echo/v4"
 
 // addOriginsRoutes adds the origins routes to the router
 func (r *Router) addOriginRoutes(g *echo.Group) {
-	g.GET("/origins", r.originsGet)
+	g.GET("/origins", r.originsList)
 	g.GET("/origins/:origin_id", r.originsGet)
 
 	g.POST("/origins", r.originsCreate)

--- a/pkg/api/v1/pools_get.go
+++ b/pkg/api/v1/pools_get.go
@@ -6,6 +6,25 @@ import (
 )
 
 // poolsGet returns a list of pools
+func (r *Router) poolsList(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	mods, err := r.poolsParamsBinding(c)
+	if err != nil {
+		r.logger.Errorw("error parsing query params", "error", err)
+		return v1BadRequestResponse(c, err)
+	}
+
+	ps, err := models.Pools(mods...).All(ctx, r.db)
+	if err != nil {
+		r.logger.Errorw("error getting pools", "error", err)
+		return v1InternalServerErrorResponse(c, err)
+	}
+
+	return v1PoolsResponse(c, ps)
+}
+
+// poolsGet returns a pool by ID
 func (r *Router) poolsGet(c echo.Context) error {
 	ctx := c.Request().Context()
 

--- a/pkg/api/v1/pools_param_binding.go
+++ b/pkg/api/v1/pools_param_binding.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 
@@ -21,7 +22,12 @@ func (r *Router) poolsParamsBinding(c echo.Context) ([]qm.QueryMod, error) {
 
 	poolID := c.Param("pool_id")
 	if poolID != "" {
+		if _, err := uuid.Parse(poolID); err != nil {
+			return nil, ErrInvalidUUID
+		}
+
 		mods = append(mods, models.PoolWhere.PoolID.EQ(poolID))
+		r.logger.Debugw("path param", "pool_id", poolID)
 	}
 
 	queryParams := []string{"slug", "protocol"}

--- a/pkg/api/v1/pools_routes.go
+++ b/pkg/api/v1/pools_routes.go
@@ -4,7 +4,7 @@ import "github.com/labstack/echo/v4"
 
 // addPoolsRoutes adds the routes for the pools API
 func (r *Router) addPoolsRoutes(g *echo.Group) {
-	g.GET("/pools", r.poolsGet)
+	g.GET("/pools", r.poolsList)
 	g.GET("/pools/:pool_id", r.poolsGet)
 
 	g.POST("/pools", r.poolCreate)

--- a/pkg/api/v1/pools_test.go
+++ b/pkg/api/v1/pools_test.go
@@ -69,12 +69,21 @@ func TestPoolRoutes(t *testing.T) {
 
 	tenantID := uuid.New().String()
 	baseURL := srv.URL + "/v1/pools"
+	missingUUID := uuid.New().String()
 
 	// doHTTPTest is a helper function that makes a request to the server and
 	// checks the response.
 	//
 	// To ensure test output has meaningful line references the function is
 	// called individually for each test case
+	doHTTPTest(t, &httpTest{
+		name:   "get pools before create",
+		status: http.StatusOK,
+		path:   baseURL,
+		method: http.MethodGet,
+		tenant: tenantID,
+	})
+
 	// POST
 	doHTTPTest(t, &httpTest{
 		name:   "happy path",
@@ -93,6 +102,7 @@ func TestPoolRoutes(t *testing.T) {
 		method: http.MethodPost,
 		tenant: tenantID,
 	})
+
 	doHTTPTest(t, &httpTest{
 		name:   "missing display name",
 		body:   `[{"protocol": "tcp"}]`,
@@ -101,6 +111,7 @@ func TestPoolRoutes(t *testing.T) {
 		method: http.MethodPost,
 		tenant: tenantID,
 	})
+
 	doHTTPTest(t, &httpTest{
 		name:   "missing protocol",
 		body:   `[{"display_name": "Bruce"}]`,
@@ -109,6 +120,7 @@ func TestPoolRoutes(t *testing.T) {
 		method: http.MethodPost,
 		tenant: tenantID,
 	})
+
 	doHTTPTest(t, &httpTest{
 		name:   "invalid protocol",
 		body:   `[{"display_name": "Nemo", "protocol": "invalid"}]`,
@@ -117,6 +129,7 @@ func TestPoolRoutes(t *testing.T) {
 		method: http.MethodPost,
 		tenant: tenantID,
 	})
+
 	doHTTPTest(t, &httpTest{
 		name:   "invalid body",
 		body:   `invalid`,
@@ -125,6 +138,7 @@ func TestPoolRoutes(t *testing.T) {
 		method: http.MethodPost,
 		tenant: tenantID,
 	})
+
 	// GET
 	doHTTPTest(t, &httpTest{
 		name:   "happy path",
@@ -133,6 +147,7 @@ func TestPoolRoutes(t *testing.T) {
 		method: http.MethodGet,
 		tenant: tenantID,
 	})
+
 	doHTTPTest(t, &httpTest{
 		name:   "happy path with query",
 		status: http.StatusOK,
@@ -140,13 +155,47 @@ func TestPoolRoutes(t *testing.T) {
 		method: http.MethodGet,
 		tenant: tenantID,
 	})
+
 	doHTTPTest(t, &httpTest{
 		name:   "not found with query",
-		status: http.StatusNotFound,
+		status: http.StatusOK,
 		path:   baseURL + "?slug=NotNemo",
 		method: http.MethodGet,
 		tenant: tenantID,
 	})
+
+	doHTTPTest(t, &httpTest{
+		name:   "list pools with invalid tenant id",
+		path:   baseURL,
+		status: http.StatusBadRequest,
+		method: http.MethodGet,
+		tenant: "123456",
+	})
+
+	doHTTPTest(t, &httpTest{
+		name:   "list pools with unknown tenant id",
+		path:   baseURL,
+		status: http.StatusOK,
+		method: http.MethodGet,
+		tenant: missingUUID,
+	})
+
+	doHTTPTest(t, &httpTest{
+		name:   "not found with path param",
+		status: http.StatusNotFound,
+		path:   baseURL + "/" + missingUUID,
+		method: http.MethodGet,
+		tenant: tenantID,
+	})
+
+	doHTTPTest(t, &httpTest{
+		name:   "bad UUID in path param",
+		status: http.StatusBadRequest,
+		path:   baseURL + "/123456",
+		method: http.MethodGet,
+		tenant: tenantID,
+	})
+
 	// DELETE
 	doHTTPTest(t, &httpTest{
 		name:   "happy path",
@@ -154,5 +203,40 @@ func TestPoolRoutes(t *testing.T) {
 		path:   baseURL + "?display_name=Nemo",
 		method: http.MethodDelete,
 		tenant: tenantID,
+	})
+}
+
+func TestPoolsGet(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	assert.NotNil(t, srv)
+
+	baseURL := srv.URL + "/v1/pools"
+
+	// Create a load balancer
+	loadBalancer, cleanupLB := createLoadBalancer(t, srv, uuid.NewString())
+	defer cleanupLB(t)
+
+	// Create a pool
+	pool, cleanupPool := createPool(t, srv, "marlin", loadBalancer.TenantID)
+	defer cleanupPool(t)
+
+	// Get the pool
+	doHTTPTest(t, &httpTest{
+		name:   "get pool by id",
+		method: http.MethodGet,
+		path:   baseURL + "/" + pool.ID,
+		status: http.StatusOK,
+		tenant: loadBalancer.TenantID,
+	})
+
+	// Get an unknown pool
+	doHTTPTest(t, &httpTest{
+		name:   "pool not found",
+		method: http.MethodGet,
+		path:   baseURL + "/bfad65a9-abe3-44af-82ce-64331c84b2ad",
+		status: http.StatusNotFound,
+		tenant: loadBalancer.TenantID,
 	})
 }


### PR DESCRIPTION
This touches the endpoints related to loadbalancers, pools, origins and frontends.  I stayed away from assignments for now.  All list endpoints should return `200` and an empty array for empty queries instead of a 404.  Queries for specific UUIDs return a 404 if the ID is not found. I also filled in a bunch of missing test cases to make sure this is working correctly.