### PR TITLE
Accept single object on post, return UUID in create response

### DIFF
--- a/pkg/api/v1/assignments_create.go
+++ b/pkg/api/v1/assignments_create.go
@@ -69,5 +69,5 @@ func (r *Router) assignmentsCreate(c echo.Context) error {
 		r.logger.Errorw("error publishing event", "error", err)
 	}
 
-	return v1CreatedResponse(c)
+	return v1AssignmentsCreatedResponse(c, assignment.AssignmentID)
 }

--- a/pkg/api/v1/frontends_create.go
+++ b/pkg/api/v1/frontends_create.go
@@ -38,7 +38,7 @@ func (r *Router) frontendCreate(c echo.Context) error {
 
 	if err := validateFrontend(&frontend); err != nil {
 		r.logger.Errorw("failed to validate frontend", "error", err)
-		return v1UnprocessableEntityResponse(c, err)
+		return v1BadRequestResponse(c, err)
 	}
 
 	if err := frontend.Insert(ctx, r.db, boil.Infer()); err != nil {

--- a/pkg/api/v1/load_balancers_create.go
+++ b/pkg/api/v1/load_balancers_create.go
@@ -80,5 +80,5 @@ func (r *Router) loadBalancerCreate(c echo.Context) error {
 		r.logger.Errorw("failed to publish load balancer message", "error", err)
 	}
 
-	return v1CreatedResponse(c)
+	return v1LoadBalancerCreatedResponse(c, lb.LoadBalancerID)
 }

--- a/pkg/api/v1/origins_test.go
+++ b/pkg/api/v1/origins_test.go
@@ -15,7 +15,7 @@ import (
 func createOrigin(t *testing.T, srv *httptest.Server, name string, poolID, tenantID string) (*origin, func(*testing.T)) {
 	t.Helper()
 
-	body := fmt.Sprintf(`[{"disabled": true,"display_name": "%s", "target": "1.1.1.1", "port": 80, "pool_id": "%s"}]`, name, poolID)
+	body := fmt.Sprintf(`{"disabled": true,"display_name": "%s", "target": "1.1.1.1", "port": 80, "pool_id": "%s"}`, name, poolID)
 
 	doHTTPTest(t, &httpTest{
 		name:   "create origin",
@@ -85,7 +85,7 @@ func TestOriginRoutes(t *testing.T) {
 	// POST
 	doHTTPTest(t, &httpTest{
 		name:   "happy path",
-		body:   `[{"disabled": true,"display_name": "The Butt", "target": "9.9.9.9", "port": 80, "pool_id": "` + pool.ID + `"}]`,
+		body:   `{"disabled": true,"display_name": "The Butt", "target": "9.9.9.9", "port": 80, "pool_id": "` + pool.ID + `"}`,
 		status: http.StatusOK,
 		path:   baseURL,
 		method: http.MethodPost,
@@ -94,8 +94,17 @@ func TestOriginRoutes(t *testing.T) {
 
 	doHTTPTest(t, &httpTest{
 		name:   "happy path",
-		body:   `[{"disabled": true,"display_name": "Fish are friends", "target": "9.9.8.8", "port": 80, "pool_id": "` + pool.ID + `"}]`,
+		body:   `{"disabled": true,"display_name": "Fish are friends", "target": "9.9.8.8", "port": 80, "pool_id": "` + pool.ID + `"}`,
 		status: http.StatusOK,
+		path:   baseURL,
+		method: http.MethodPost,
+		tenant: tenantID,
+	})
+
+	doHTTPTest(t, &httpTest{
+		name:   "list of origins",
+		body:   `[{"disabled": true,"display_name": "The Butt", "target": "9.9.9.9", "port": 80, "pool_id": "` + pool.ID + `"},{"disabled": true,"display_name": "The Beard", "target": "9.9.9.10", "port": 80, "pool_id": "` + pool.ID + `"}]`,
+		status: http.StatusBadRequest,
 		path:   baseURL,
 		method: http.MethodPost,
 		tenant: tenantID,
@@ -121,7 +130,7 @@ func TestOriginRoutes(t *testing.T) {
 
 	doHTTPTest(t, &httpTest{
 		name:   "missing pool_id",
-		body:   `[{"disabled": true,"display_name": "the-butt", "target": "2.0.0.1", "port": 80}]`,
+		body:   `{"disabled": true,"display_name": "the-butt", "target": "2.0.0.1", "port": 80}`,
 		status: http.StatusBadRequest,
 		path:   baseURL,
 		method: http.MethodPost,

--- a/pkg/api/v1/pools_test.go
+++ b/pkg/api/v1/pools_test.go
@@ -16,7 +16,7 @@ import (
 func createPool(t *testing.T, srv *httptest.Server, name string, tenantID string) (*pool, func(t *testing.T)) {
 	t.Helper()
 
-	body := `[{"display_name": "` + name + `", "protocol": "tcp"}]`
+	body := `{"display_name": "` + name + `", "protocol": "tcp"}`
 
 	baseURL := srv.URL + "/v1/pools"
 
@@ -87,7 +87,7 @@ func TestPoolRoutes(t *testing.T) {
 	// POST
 	doHTTPTest(t, &httpTest{
 		name:   "happy path",
-		body:   `[{"display_name": "Nemo", "protocol": "tcp"}]`,
+		body:   `{"display_name": "Nemo", "protocol": "tcp"}`,
 		status: http.StatusOK,
 		path:   baseURL,
 		method: http.MethodPost,
@@ -96,7 +96,7 @@ func TestPoolRoutes(t *testing.T) {
 
 	doHTTPTest(t, &httpTest{
 		name:   "duplicate",
-		body:   `[{"display_name": "Nemo", "protocol": "tcp"}]`,
+		body:   `{"display_name": "Nemo", "protocol": "tcp"}`,
 		status: http.StatusInternalServerError,
 		path:   baseURL,
 		method: http.MethodPost,
@@ -104,8 +104,17 @@ func TestPoolRoutes(t *testing.T) {
 	})
 
 	doHTTPTest(t, &httpTest{
+		name:   "multiple pools",
+		body:   `[{"display_name": "Nemo", "protocol": "tcp"},{"display_name": "Dory", "protocol": "tcp"}]`,
+		status: http.StatusBadRequest,
+		path:   baseURL,
+		method: http.MethodPost,
+		tenant: tenantID,
+	})
+
+	doHTTPTest(t, &httpTest{
 		name:   "missing display name",
-		body:   `[{"protocol": "tcp"}]`,
+		body:   `{"protocol": "tcp"}`,
 		status: http.StatusBadRequest,
 		path:   baseURL,
 		method: http.MethodPost,
@@ -114,7 +123,7 @@ func TestPoolRoutes(t *testing.T) {
 
 	doHTTPTest(t, &httpTest{
 		name:   "missing protocol",
-		body:   `[{"display_name": "Bruce"}]`,
+		body:   `{"display_name": "Bruce"}`,
 		status: http.StatusOK,
 		path:   baseURL,
 		method: http.MethodPost,
@@ -123,7 +132,7 @@ func TestPoolRoutes(t *testing.T) {
 
 	doHTTPTest(t, &httpTest{
 		name:   "invalid protocol",
-		body:   `[{"display_name": "Nemo", "protocol": "invalid"}]`,
+		body:   `{"display_name": "Nemo", "protocol": "invalid"}`,
 		status: http.StatusBadRequest,
 		path:   baseURL,
 		method: http.MethodPost,

--- a/pkg/api/v1/responses.go
+++ b/pkg/api/v1/responses.go
@@ -19,15 +19,73 @@ func v1DeletedResponse(c echo.Context) error {
 	})
 }
 
-func v1CreatedResponse(c echo.Context) error {
+func v1AssignmentsCreatedResponse(c echo.Context, id string) error {
+	return c.JSON(http.StatusOK, struct {
+		Version      string `json:"version"`
+		Message      string `json:"message"`
+		Status       int    `json:"status"`
+		AssignmentID string `json:"assignment_id,omitempty"`
+	}{
+		Message:      "resource created",
+		Version:      apiVersion,
+		Status:       http.StatusOK,
+		AssignmentID: id,
+	})
+}
+
+func v1LoadBalancerCreatedResponse(c echo.Context, id string) error {
+	return c.JSON(http.StatusOK, struct {
+		Version        string `json:"version"`
+		Message        string `json:"message"`
+		Status         int    `json:"status"`
+		LoadBalancerID string `json:"load_balancer_id"`
+	}{
+		Message:        "resource created",
+		Version:        apiVersion,
+		Status:         http.StatusOK,
+		LoadBalancerID: id,
+	})
+}
+
+func v1FrontendCreatedResponse(c echo.Context, id string) error {
+	return c.JSON(http.StatusOK, struct {
+		Version    string `json:"version"`
+		Message    string `json:"message"`
+		Status     int    `json:"status"`
+		FrontendID string `json:"frontend_id"`
+	}{
+		Message:    "resource created",
+		Version:    apiVersion,
+		Status:     http.StatusOK,
+		FrontendID: id,
+	})
+}
+
+func v1OriginCreatedResponse(c echo.Context, id string) error {
+	return c.JSON(http.StatusOK, struct {
+		Version  string `json:"version"`
+		Message  string `json:"message"`
+		Status   int    `json:"status"`
+		OriginID string `json:"origin_id,omitempty"`
+	}{
+		Message:  "resource created",
+		Version:  apiVersion,
+		Status:   http.StatusOK,
+		OriginID: id,
+	})
+}
+
+func v1PoolCreatedResponse(c echo.Context, id string) error {
 	return c.JSON(http.StatusOK, struct {
 		Version string `json:"version"`
 		Message string `json:"message"`
 		Status  int    `json:"status"`
+		PoolID  string `json:"pool_id,omitempty"`
 	}{
 		Message: "resource created",
 		Version: apiVersion,
 		Status:  http.StatusOK,
+		PoolID:  id,
 	})
 }
 


### PR DESCRIPTION
All POST endpoints only accept a single object and return the UUID of the created object in the response.