### PR TITLE
Update pool routes with tenant id

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -622,8 +622,6 @@ go.etcd.io/etcd/api/v3 v3.5.4/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dY
 go.etcd.io/etcd/client/pkg/v3 v3.5.4/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v2 v2.305.4/go.mod h1:Ud+VUwIi9/uQHOMA+4ekToJ12lTxlv0zB/+DHwTGEbU=
 go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/gq3kiY=
-go.infratographer.com/x v0.0.1 h1:Qky1OcdnoD3S1DdZtvQAcqWaeQBbHqw1aq/gzn2hcjc=
-go.infratographer.com/x v0.0.1/go.mod h1:X87s1QHNKOrY2W3VowdoOK2OtXeR8o9kaJp1P5NCbDE=
 go.infratographer.com/x v0.0.2 h1:x/vjD4k8qBgHUdP92oBzPOkh54K8HTh6Rjm03rY+Txw=
 go.infratographer.com/x v0.0.2/go.mod h1:X87s1QHNKOrY2W3VowdoOK2OtXeR8o9kaJp1P5NCbDE=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/pkg/api/v1/pools_create.go
+++ b/pkg/api/v1/pools_create.go
@@ -20,7 +20,7 @@ func (r *Router) poolCreate(c echo.Context) error {
 		return v1BadRequestResponse(c, err)
 	}
 
-	tenantID, err := r.parseTenantID(c)
+	tenantID, err := r.parseUUID(c, "tenant_id")
 	if err != nil {
 		r.logger.Errorw("error parsing tenant id", "error", err)
 		return v1BadRequestResponse(c, err)

--- a/pkg/api/v1/pools_routes.go
+++ b/pkg/api/v1/pools_routes.go
@@ -4,11 +4,11 @@ import "github.com/labstack/echo/v4"
 
 // addPoolsRoutes adds the routes for the pools API
 func (r *Router) addPoolsRoutes(g *echo.Group) {
-	g.GET("/pools", r.poolsList)
+	g.GET("/tenant/:tenant_id/pools", r.poolsList)
 	g.GET("/pools/:pool_id", r.poolsGet)
 
-	g.POST("/pools", r.poolCreate)
+	g.POST("/tenant/:tenant_id/pools", r.poolCreate)
 
-	g.DELETE("/pools", r.poolDelete)
+	g.DELETE("/tenant/:tenant_id/pools", r.poolDelete)
 	g.DELETE("/pools/:pool_id", r.poolDelete)
 }


### PR DESCRIPTION
Update pool routes with tenant id as a path parameter instead of a header.