### PR TITLE
Add service and ingress to chart

### DIFF
--- a/chart/load-balancer-api/templates/deployment.yaml
+++ b/chart/load-balancer-api/templates/deployment.yaml
@@ -64,6 +64,9 @@ spec:
             - name: hc
               containerPort: {{ .Values.api.healthCheckPort | default "8080" }}
               protocol: TCP
+            - name: http
+              containerPort: {{ .Values.api.listenPort | default "8080" }}
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz

--- a/chart/load-balancer-api/templates/ingress.yaml
+++ b/chart/load-balancer-api/templates/ingress.yaml
@@ -1,0 +1,39 @@
+---
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "common.names.fullname" . -}}
+{{- if empty .Values.ingress.hosts }}
+{{- fail ".Values.ingress.hosts must contain at least one entry" }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+    {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ $fullName }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  ingressClassName: nginx
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host  | quote }}
+      http:
+        paths:
+          {{- range (.paths | default (list "/")) }}
+          - pathType: {{ $.Values.ingress.pathType | default "Prefix" | quote }}
+            path: {{ . | quote }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: web
+  {{- end }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/load-balancer-api/templates/ingress.yaml
+++ b/chart/load-balancer-api/templates/ingress.yaml
@@ -29,7 +29,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  name: web
+                  name: http
   {{- end }}
   {{- end }}
   {{- with .Values.ingress.tls }}

--- a/chart/load-balancer-api/templates/service.yaml
+++ b/chart/load-balancer-api/templates/service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: {{ .Values.api.listenPort }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  type: {{ .Values.service.type }}

--- a/chart/load-balancer-api/values.yaml
+++ b/chart/load-balancer-api/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/infratographr/load-balancer-api
+  repository: ghcr.io/infratographer/load-balancer-api
   pullPolicy: IfNotPresent
   tag: "v0.0.1"
 

--- a/chart/load-balancer-api/values.yaml
+++ b/chart/load-balancer-api/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/infratographer/load-balancer-api
+  repository: ghcr.io/infratograpr/load-balancer-api
   pullPolicy: IfNotPresent
   tag: "v0.0.1"
 
@@ -20,9 +20,18 @@ podAnnotations: {}
 service:
   type: ClusterIP
   port: 80
+  sessionAffinity: None
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts: []
+  tls: {}
 
 api:
   replicas: 1
+  listenPort: 7608
+  healthCheckPort: 7608
   extraLabels: {}
   extraAnnotations: {}
   extraEnvVars: {}
@@ -39,7 +48,6 @@ api:
 
 reloader:
   enabled: false
-
 
 cockroachdb:
   enabled: false

--- a/chart/load-balancer-api/values.yaml
+++ b/chart/load-balancer-api/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: ghcr.io/infratograpr/load-balancer-api
+  repository: ghcr.io/infratographr/load-balancer-api
   pullPolicy: IfNotPresent
   tag: "v0.0.1"
 


### PR DESCRIPTION
This adds a service and optional ingress to the chart for the load-balancer-api.