### PR TITLE
Modify urn format to match standard format

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # Used to install CRDB into the devcontainer
 FROM cockroachdb/cockroach:latest-v22.2 as CRDB
 
-FROM mcr.microsoft.com/vscode/devcontainers/go:0-1.19-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-1.20-bullseye
 
 # Set up crdb
 RUN mkdir /usr/local/lib/cockroach

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        VARIANT: 1.19-bullseye
+        VARIANT: 1.20-bullseye
         NODE_VERSION: "none"
     command:
       - .devcontainer/scripts/app-entrypoint.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.infratographer.com/load-balancer-api
 
-go 1.19
+go 1.20
 
 require (
 	github.com/dspinhirne/netaddr-go v0.0.0-20211008142535-a4c5bccad224

--- a/internal/pubsub/assignments.go
+++ b/internal/pubsub/assignments.go
@@ -1,18 +1,12 @@
 package pubsub
 
 import (
-	"fmt"
-
 	"go.infratographer.com/x/pubsubx"
 )
 
 // NewAssignmentURN creates a new assignment URN
 func NewAssignmentURN(assignmentID string) string {
 	return newURN("assignment", assignmentID)
-}
-
-func newURN(kind, id string) string {
-	return fmt.Sprintf("urn:infratographer:infratographer.com:%s:%s/", kind, id)
 }
 
 // NewAssignmentMessage creates a new assignment message

--- a/internal/pubsub/urns.go
+++ b/internal/pubsub/urns.go
@@ -1,0 +1,7 @@
+package pubsub
+
+import "fmt"
+
+func newURN(kind, id string) string {
+	return fmt.Sprintf("urn:infratographer:%s:%s", kind, id)
+}

--- a/internal/pubsub/urns_test.go
+++ b/internal/pubsub/urns_test.go
@@ -1,0 +1,29 @@
+package pubsub
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewURN(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+		id   string
+		urn  string
+	}{
+		{
+			name: "example urn",
+			kind: "testThing",
+			id:   "9def378e-be7b-4566-83b5-20ae8ccf99cb",
+			urn:  "urn:infratographer:testThing:9def378e-be7b-4566-83b5-20ae8ccf99cb",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := newURN(tt.kind, tt.id)
+			assert.Equal(t, tt.urn, out)
+		})
+	}
+}

--- a/pkg/api/v1/tools.go
+++ b/pkg/api/v1/tools.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const someTestJWTURN = "urn:infratographer:infratographer.com:identity:some-jwt"
+const someTestJWTURN = "urn:infratographer:identity:some-jwt"
 
 type httpTest struct {
 	name   string


### PR DESCRIPTION
Update the URN format for creating loadbalancers (and other things that share the `newURN` function).