### PR TITLE
Fix whitespace in chart definition for secret environment

### DIFF
--- a/chart/load-balancer-api/templates/deployment.yaml
+++ b/chart/load-balancer-api/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
           {{- end }}
           envFrom:
             - secretRef:
-              name: {{ .Values.api.db.uriSecret }}
+                name: {{ .Values.api.db.uriSecret }}
           {{- with .Values.api.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Fix a bug with the load-balancer-api deployment definition.