### PR TITLE
correct livenessProbe

### DIFF
--- a/chart/load-balancer-api/templates/deployment.yaml
+++ b/chart/load-balancer-api/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: http
           readinessProbe:
             httpGet:


### PR DESCRIPTION
When migrating to echox, liveness endpoint is proved by default. I forgot to update the livenessProbe in the helm chart to point to livez instead of healthz.