### PR TITLE
Update Makefile to run server during code gen

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
 					"editor.defaultFormatter": "golang.go"
 				},
 				"go.buildTags": "testtools",
+				"go.formatTool": "goimports",
 				"go.lintTool": "golangci-lint",
 				"gopls": {
 					"formatting.gofumpt": true,

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: lint test
+all: lint tests binary ## Runs lint, tests, and builds the binary
 
 PHONY: help all test coverage lint golint clean vendor docker-up docker-down unit-test
 GOOS=linux
@@ -13,7 +13,7 @@ APP_NAME=loadbalancer-api
 help: Makefile ## Print help
 	@grep -h "##" $(MAKEFILE_LIST) | grep -v grep | sed -e 's/:.*##/#/' | column -c 2 -t -s#
 
-tests: | unit-test
+tests: | unit-tests
 
 unit-tests: ## Runs unit tests
 	@echo --- Running unit tests...
@@ -37,11 +37,11 @@ golint:
 clean: ## Clean up all the things
 	@echo --- Cleaning...
 	@date --rfc-3339=seconds
-	@rm -rf ./dist/
+	@rm -rf ./bin/
 	@rm -rf coverage.out
 	@go clean -testcache
 
-binary: | generate ## Builds the binary
+binary: | vendor  ## Builds the binary
 	@echo --- Building binary...
 	@date --rfc-3339=seconds
 	@go build -o bin/${APP_NAME} main.go
@@ -52,7 +52,9 @@ vendor: ## Vendors dependencies
 	@go mod tidy
 	@go mod download
 
-testclient: ## Regenerates the test client in graphclient
+testclient:| background-run .testclient kill-running ## Regenerates the test client in graphclient
+
+.testclient:
 	@echo --- Generating test graph client...
 	@date --rfc-3339=seconds
 	@go generate ./internal/graphclient
@@ -62,7 +64,24 @@ dev-nats: ## Initializes nats
 	@date --rfc-3339=seconds
 	@.devcontainer/scripts/nats_account.sh
 
-generate: vendor ## Generates code
+generate: background-run .generate kill-running ## Generates code
+
+.generate:
 	@echo --- Generating code...
 	@date --rfc-3339=seconds
 	@go generate ./...
+
+go-run: ## Runs the binary
+	@echo --- Running binary...
+	@date --rfc-3339=seconds
+	@go run main.go serve --playground
+
+background-run: | binary ## Runs the binary in the background
+	@echo --- Running binary in the background...
+	@date --rfc-3339=seconds
+	@./bin/${APP_NAME} serve &
+
+kill-running: ## Kills the running binary from pid file
+	@echo --- Killing background binary...
+	@date --rfc-3339=seconds
+	@kill $$(cat /tmp/lba.pid)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"strconv"
+	"syscall"
 
 	"entgo.io/ent/dialect"
 	"github.com/labstack/echo/v4/middleware"
@@ -17,7 +20,10 @@ import (
 	"go.infratographer.com/load-balancer-api/internal/graphapi"
 )
 
-const defaultLBAPIListenAddr = ":7608"
+const (
+	defaultLBAPIListenAddr = ":7608"
+	pidFileName            = "/tmp/lba.pid"
+)
 
 var (
 	enablePlayground bool
@@ -28,6 +34,13 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start the load balancer Graph API",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := writePidFile(pidFileName); err != nil {
+			logger.Error("failed to write pid file", zap.Error(err))
+			return err
+		}
+
+		defer os.Remove(pidFileName)
+
 		return serve(cmd.Context())
 	},
 }
@@ -40,6 +53,28 @@ func init() {
 	// only available as a CLI arg because it shouldn't be something that could accidentially end up in a config file or env var
 	serveCmd.Flags().BoolVar(&serveDevMode, "dev", false, "dev mode: enables playground, disables all auth checks, sets CORS to allow all, pretty logging, etc.")
 	serveCmd.Flags().BoolVar(&enablePlayground, "playground", false, "enable the graph playground")
+}
+
+// Write a pid file, but first make sure it doesn't exist with a running pid.
+func writePidFile(pidFile string) error {
+	// Read in the pid file as a slice of bytes.
+	if piddata, err := os.ReadFile(pidFile); err == nil {
+		// Convert the file contents to an integer.
+		if pid, err := strconv.Atoi(string(piddata)); err == nil {
+			// Look for the pid in the process list.
+			if process, err := os.FindProcess(pid); err == nil {
+				// Send the process a signal zero kill.
+				if err := process.Signal(syscall.Signal(0)); err == nil {
+					// We only get an error if the pid isn't running, or it's not ours.
+					return err
+				}
+			}
+		}
+	}
+
+	// If we get here, then the pidfile didn't exist,
+	// or the pid in it doesn't belong to the user running this app.
+	return os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())), 0o664) // nolint: gomnd
 }
 
 func serve(ctx context.Context) error {
@@ -82,7 +117,7 @@ func serve(ctx context.Context) error {
 
 	srv.AddHandler(handler)
 
-	if err := srv.Run(); err != nil {
+	if err := srv.RunWithContext(ctx); err != nil {
 		logger.Error("failed to run server", zap.Error(err))
 	}
 

--- a/internal/graphapi/tenant.resolvers.go
+++ b/internal/graphapi/tenant.resolvers.go
@@ -9,11 +9,10 @@ import (
 	"fmt"
 
 	"entgo.io/contrib/entgql"
-	"go.infratographer.com/x/gidx"
-
 	"go.infratographer.com/load-balancer-api/internal/ent/generated"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/loadbalancer"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/pool"
+	"go.infratographer.com/x/gidx"
 )
 
 // Tenant is the resolver for the tenant field.


### PR DESCRIPTION
# Summary

* Adds a pid file to `/tmp/lba.pid` that is used to kill the running instance of `load balancer-api`
* Fixes code gen targets in the `Makefile`