### PR TITLE
Fix syntax issue in API chart

### DIFF
--- a/chart/load-balancer-api/templates/deployment.yaml
+++ b/chart/load-balancer-api/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
             - name: LOADBALANCERAPI_NATS_CREDS_FILE
               value: "{{ .Values.api.events.credsPath }}"
           {{- end }}
-          {- if .Values.api.oidc.enabled }}
+          {{- if .Values.api.oidc.enabled }}
           {{- with .Values.api.oidc.audience }}
             - name: LOADBALANCERAPI_OIDC_AUDIENCE
               value: "{{ . }}"


### PR DESCRIPTION
- Missing brackets in deployment template were preventing the chart from being used.