### PR TITLE
Update Dockerfile to work with goreleaser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
-FROM golang:1.20.5 AS builder
-
-COPY . /src
-WORKDIR /src
-
-# Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o bin/loadbalancer-api .
-
-# Pass in name as --build-arg
 FROM gcr.io/distroless/static:nonroot
+
 # `nonroot` coming from distroless
 USER 65532:65532
 
-COPY  --from=builder /src/bin/loadbalancer-api /loadbalancer-api
+# Copy the binary that goreleaser built
+COPY  loadbalancer-api /loadbalancer-api
 
 # Run the web service on container startup.
 ENTRYPOINT ["/loadbalancer-api"]


### PR DESCRIPTION
Cleanup Dockerfile so we let goreleaser handle builds and aren't wasting time double building our artifacts.