### PR TITLE
Add migrateOnInit to chart

### DIFF
--- a/chart/load-balancer-api/templates/deployment.yaml
+++ b/chart/load-balancer-api/templates/deployment.yaml
@@ -37,6 +37,26 @@ spec:
       securityContext:
         {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
       {{- end }}
+{{- if .Values.api.migrateOnInit  }}
+      initContainers:
+        - name: {{ .Chart.Name }}-migrate
+          envFrom:
+            - secretRef:
+                name: {{ .Values.api.db.uriSecret }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - migrate
+            - up
+          volumeMounts:
+            {{- if .Values.api.db.certSecret }}
+            - name: dbcerts
+              mountPath: "/dbcerts"
+              readOnly: true
+            {{- end }}
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.api.extraEnvVars }}

--- a/chart/load-balancer-api/values.yaml
+++ b/chart/load-balancer-api/values.yaml
@@ -49,6 +49,7 @@ api:
   db:
     uriSecret: "" 
     certSecret: ""
+  migrateOnInit: false 
 
   oidc:
     enabled: false


### PR DESCRIPTION
Adds migrateOnInit feature similar to other APIs. This will allow for schema migration to be run if necessary during initialization.