### PR TITLE
oidc.enabled environment variable should be OIDC_ENABLED

### DIFF
--- a/chart/load-balancer-api/templates/api-config.yaml
+++ b/chart/load-balancer-api/templates/api-config.yaml
@@ -7,7 +7,7 @@ metadata:
 data:
   LOADBALANCERAPI_EVENTS_PUBLISHER_PREFIX: "{{ .Values.api.events.topicPrefix }}"
   LOADBALANCERAPI_EVENTS_PUBLISHER_URL: "{{ .Values.api.events.connectionURL }}"
-  LOADBALANCERAPI_OIDC: "{{ .Values.api.oidc.enabled }}"
+  LOADBALANCERAPI_OIDC_ENABLED: "{{ .Values.api.oidc.enabled }}"
   LOADBALANCERAPI_OIDC_AUDIENCE: "{{ .Values.api.oidc.audience }}"
   LOADBALANCERAPI_OIDC_ISSUER: "{{ .Values.api.oidc.issuer }}"
   LOADBALANCERAPI_OIDC_JWKS_REMOTE_TIMEOUT: "{{ .Values.api.oidc.jwksRemoteTimeout }}"


### PR DESCRIPTION
With the previous configuration, oidc wasn't getting enabled resulting in issues on depending middleware.