### PR TITLE
Pin to go 1.20.5 for tests

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Set up Go for ${{ matrix.ci-database }}
         uses: actions/setup-go@v4
         with:
-          go-version-file: 'go.mod'
+          #pinning to 1.20.5 until https://github.com/testcontainers/testcontainers-go/issues/1359 is resolved
+          #go-version-file: "go.mod"
+          go-version: "1.20.5"
       - name: Install atlas for db migrations on ${{ matrix.ci-database }}
         run: go install ariga.io/atlas/cmd/atlas@latest
 


### PR DESCRIPTION
There is a current bug somewhere in the mix of go 1.20.6 <- Moby -> testcontainers. This is being worked out in https://github.com/testcontainers/testcontainers-go/issues/1359 . Until this is fixed, the workaround seems to be pinning to go 1.20.5 for testing