### PR TITLE
port name ent validations

### DIFF
--- a/internal/ent/generated/runtime.go
+++ b/internal/ent/generated/runtime.go
@@ -179,7 +179,21 @@ func init() {
 	// portDescName is the schema descriptor for name field.
 	portDescName := portFields[2].Descriptor()
 	// port.NameValidator is a validator for the "name" field. It is called by the builders before save.
-	port.NameValidator = portDescName.Validators[0].(func(string) error)
+	port.NameValidator = func() func(string) error {
+		validators := portDescName.Validators
+		fns := [...]func(string) error{
+			validators[0].(func(string) error),
+			validators[1].(func(string) error),
+		}
+		return func(name string) error {
+			for _, fn := range fns {
+				if err := fn(name); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}()
 	// portDescLoadBalancerID is the schema descriptor for load_balancer_id field.
 	portDescLoadBalancerID := portFields[3].Descriptor()
 	// port.LoadBalancerIDValidator is a validator for the "load_balancer_id" field. It is called by the builders before save.

--- a/internal/ent/schema/port.go
+++ b/internal/ent/schema/port.go
@@ -8,6 +8,7 @@ import (
 	"entgo.io/ent/schema/field"
 	"entgo.io/ent/schema/index"
 
+	"go.infratographer.com/load-balancer-api/internal/ent/schema/validations"
 	"go.infratographer.com/load-balancer-api/x/pubsubinfo"
 
 	"go.infratographer.com/x/entx"
@@ -46,6 +47,7 @@ func (Port) Fields() []ent.Field {
 				entgql.OrderField("number"),
 			),
 		field.String("name").
+			Validate(validations.PortName).
 			NotEmpty().
 			Annotations(
 				entgql.OrderField("name"),

--- a/internal/ent/schema/validations/errors.go
+++ b/internal/ent/schema/validations/errors.go
@@ -1,0 +1,22 @@
+package validations
+
+import (
+	"errors"
+)
+
+var (
+	// ErrPortNameLength is returned when a port name is not between 1 and 15 characters long
+	ErrPortNameLength = errors.New("port name must be between 1 and 15 characters long")
+
+	// ErrPortNameHyphens is returned when a port name begins or ends with a hyphen
+	ErrPortNameHyphens = errors.New("port name must not begin or end with a hyphen")
+
+	// ErrPortNameAdjacentHyphens is returned when a port name contains adjacent hyphens
+	ErrPortNameAdjacentHyphens = errors.New("port name must not contain adjacent hyphens")
+
+	// ErrPortNameOneLetter is returned when a port name does not contain at least one letter
+	ErrPortNameOneLetter = errors.New("port name must contain at least one letter A-Z or a-z")
+
+	// ErrPortNameInvalidChars is returned when a port name contains invalid characters
+	ErrPortNameInvalidChars = errors.New("port name must contain only letters A-Z or a-z, digits 0-9, and hyphens")
+)

--- a/internal/ent/schema/validations/validations.go
+++ b/internal/ent/schema/validations/validations.go
@@ -1,0 +1,34 @@
+// Package validations contains validation functions for ent fields
+package validations
+
+import "strings"
+
+// PortName validates a port name
+func PortName(s string) error {
+	// MUST be at least 1 character and no more than 15 characters long
+	if len(s) > 15 || len(s) < 1 {
+		return ErrPortNameLength
+	}
+
+	// MUST contain only US-ASCII [ANSI.X3.4-1986] letters 'A' - 'Z' and 'a' - 'z', digits '0' - '9', and hyphens ('-', ASCII 0x2D or decimal 45)
+	if strings.ContainsAny(s, "~`!@#$%^&*()_+={[}]|\\:;\"'<,>.?/") {
+		return ErrPortNameInvalidChars
+	}
+
+	// MUST contain at least one letter ('A' - 'Z' or 'a' - 'z')
+	if !strings.ContainsAny(s, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ") {
+		return ErrPortNameOneLetter
+	}
+
+	// hyphens MUST NOT be adjacent to other hyphens
+	if strings.Contains(s, "--") {
+		return ErrPortNameAdjacentHyphens
+	}
+
+	// MUST NOT begin or end with a hyphen
+	if strings.HasPrefix(s, "-") || strings.HasSuffix(s, "-") {
+		return ErrPortNameHyphens
+	}
+
+	return nil
+}

--- a/internal/ent/schema/validations/validations_test.go
+++ b/internal/ent/schema/validations/validations_test.go
@@ -1,0 +1,38 @@
+package validations
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPorName(t *testing.T) {
+	testCases := []struct {
+		name          string
+		portName      string
+		expectedError error
+	}{
+		{"empty name", "", ErrPortNameLength},
+		{"name > 15 chars", "port123456789011", ErrPortNameLength},
+		{"valid name", "porty", nil},
+		{"name with hyphen", "porty-123", nil},
+		{"name with hyphen at beginning", "-porty", ErrPortNameHyphens},
+		{"name with hyphen at end", "porty-", ErrPortNameHyphens},
+		{"name with adjacent hyphens", "porty--123", ErrPortNameAdjacentHyphens},
+		{"name with no letters", "123456789012345", ErrPortNameOneLetter},
+		{"name with invalid chars", "porty!", ErrPortNameInvalidChars},
+		{"name with no chars", "8080", ErrPortNameOneLetter},
+	}
+
+	for _, tt := range testCases {
+		// go vet
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := PortName(tt.portName)
+			if !errors.Is(err, tt.expectedError) {
+				t.Errorf("expected error %v, got %v", tt.expectedError, err)
+			}
+		})
+	}
+}

--- a/internal/graphapi/loadbalancer_test.go
+++ b/internal/graphapi/loadbalancer_test.go
@@ -98,7 +98,7 @@ func TestFullLoadBalancerLifecycle(t *testing.T) {
 	assert.Equal(t, ownerID, createdLB.Owner.ID)
 
 	createdPortResp, err := graphTestClient().LoadBalancerPortCreate(ctx, graphclient.CreateLoadBalancerPortInput{
-		Name:           gofakeit.DomainName(),
+		Name:           gofakeit.PetName(),
 		Number:         8080,
 		LoadBalancerID: createdLB.ID,
 	})

--- a/internal/graphapi/port_test.go
+++ b/internal/graphapi/port_test.go
@@ -20,7 +20,7 @@ func TestFullLoadBalancerPortLifecycle(t *testing.T) {
 	ctx = context.WithValue(ctx, permissions.CheckerCtxKey, permissions.DefaultAllowChecker)
 
 	lb := (&LoadBalancerBuilder{}).MustNew(ctx)
-	name := gofakeit.DomainName()
+	name := gofakeit.PetName()
 
 	createdPortResp, err := graphTestClient().LoadBalancerPortCreate(ctx, graphclient.CreateLoadBalancerPortInput{
 		Name:           name,


### PR DESCRIPTION
Prevent loadbalancer port names that are invalid, per [RFC 6335](https://www.rfc-archive.org/getrfc.php?rfc=6335)

<img width="912" alt="Screen Shot 2023-08-04 at 2 53 49 PM" src="https://github.com/infratographer/load-balancer-api/assets/14932234/f6fb8ee6-5b5e-4bc3-9888-4bb9ac033040">


/relates to https://github.com/infratographer/load-balancer-operator/pull/131