### PR TITLE
Add cluster info to OpenTelemetry Attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ coverage.txt
 
 # binary
 load-balancer-api
+
+# don't ignore folders containing the name of the binary
+!load-balancer-api/

--- a/chart/load-balancer-api/templates/_otel-attributes.tpl
+++ b/chart/load-balancer-api/templates/_otel-attributes.tpl
@@ -1,0 +1,25 @@
+# templates/_otel-attributes.tpl
+# Attributes included here will be added to every span and every metric that
+# passes through the OpenTelemetry Collector in this service's namespace.
+# Most custom instrumentation should be done within the service's code.
+# This file is a good place to include k8s cluster info that's hard to access elsewhere.
+{{- define "otel_attributes" }}
+- key: k8s.cluster.endpoint
+  value: {{ .Values.clusterInfo.apiEndpoint }}
+  action: insert
+- key: k8s.cluster.class
+  value: {{ .Values.clusterInfo.class }}
+  action: insert
+- key: k8s.cluster.fqdn
+  value: {{ .Values.clusterInfo.fqdn }}
+  action: insert
+- key: k8s.cluster.name
+  value: {{ .Values.clusterInfo.name }}
+  action: insert
+- key: metal.facility
+  value: {{ .Values.clusterInfo.facility }}
+  action: insert
+- key: metal.region
+  value: {{ .Values.clusterInfo.region }}
+  action: insert
+{{- end }}

--- a/chart/load-balancer-api/values.yaml
+++ b/chart/load-balancer-api/values.yaml
@@ -103,3 +103,6 @@ api:
 
 reloader:
   enabled: false
+
+k8s-otel-collector:
+  include_otel_attributes: true


### PR DESCRIPTION
# Summary of Changes

Adds template to helm chart to expose cluster info as span attributes.

