### PR TITLE
Add Resolver Validations

### DIFF
--- a/internal/graphapi/errors.go
+++ b/internal/graphapi/errors.go
@@ -8,5 +8,8 @@ var ErrPortNumberInUse = errors.New("port number already in use")
 // ErrRestrictedPortNumber is returned when a port number is restricted.
 var ErrRestrictedPortNumber = errors.New("port number restricted")
 
-// ErrOwnerConflict is returned when ownerships of resources are conflicting
-var ErrOwnerConflict = errors.New("conflicting ownership")
+// ErrPortNotFound is returned when one or more ports are not found
+var ErrPortNotFound = errors.New("one or more ports not found")
+
+// ErrPoolNotFound is returned when one or more pools are not found
+var ErrPoolNotFound = errors.New("one or more pools not found")

--- a/internal/graphapi/errors.go
+++ b/internal/graphapi/errors.go
@@ -7,3 +7,6 @@ var ErrPortNumberInUse = errors.New("port number already in use")
 
 // ErrRestrictedPortNumber is returned when a port number is restricted.
 var ErrRestrictedPortNumber = errors.New("port number restricted")
+
+// ErrOwnerConflict is returned when ownerships of resources are conflicting
+var ErrOwnerConflict = errors.New("conflicting ownership")

--- a/internal/graphapi/loadbalancer_test.go
+++ b/internal/graphapi/loadbalancer_test.go
@@ -90,9 +90,6 @@ func TestCreate_loadBalancer(t *testing.T) {
 	locationID := gidx.MustNewID(locationPrefix)
 	name := gofakeit.DomainName()
 
-	lb := (&LoadBalancerBuilder{}).MustNew(ctx)
-	port := (&PortBuilder{Name: "port80", LoadBalancerID: lb.ID, Number: 80}).MustNew(ctx)
-
 	testCases := []struct {
 		TestName   string
 		Input      graphclient.CreateLoadBalancerInput
@@ -123,11 +120,6 @@ func TestCreate_loadBalancer(t *testing.T) {
 			TestName: "fails to create loadbalancer with empty locationID",
 			Input:    graphclient.CreateLoadBalancerInput{Name: name, ProviderID: prov.ID, OwnerID: ownerID, LocationID: ""},
 			errorMsg: "value is less than the required length",
-		},
-		{
-			TestName: "fails to create loadbalancer with another loadbalancer's port",
-			Input:    graphclient.CreateLoadBalancerInput{Name: name, ProviderID: prov.ID, OwnerID: ownerID, LocationID: locationID, PortIDs: []gidx.PrefixedID{port.ID}},
-			errorMsg: "is already connected to a different load_balancer_id",
 		},
 	}
 
@@ -171,8 +163,6 @@ func TestUpdate_loadBalancer(t *testing.T) {
 	ctx = context.WithValue(ctx, permissions.CheckerCtxKey, permissions.DefaultAllowChecker)
 
 	lb := (&LoadBalancerBuilder{}).MustNew(ctx)
-	lb2 := (&LoadBalancerBuilder{}).MustNew(ctx)
-	port := (&PortBuilder{LoadBalancerID: lb2.ID}).MustNew(ctx)
 	updateName := gofakeit.DomainName()
 	emptyName := ""
 
@@ -196,11 +186,6 @@ func TestUpdate_loadBalancer(t *testing.T) {
 			TestName: "fails to update name to empty",
 			Input:    graphclient.UpdateLoadBalancerInput{Name: &emptyName},
 			errorMsg: "value is less than the required length",
-		},
-		{
-			TestName: "fails to update loadbalancer with another loadbalancer's port",
-			Input:    graphclient.UpdateLoadBalancerInput{AddPortIDs: []gidx.PrefixedID{port.ID}},
-			errorMsg: "is already connected to a different load_balancer_id",
 		},
 	}
 

--- a/internal/graphapi/loadbalancer_test.go
+++ b/internal/graphapi/loadbalancer_test.go
@@ -90,6 +90,9 @@ func TestCreate_loadBalancer(t *testing.T) {
 	locationID := gidx.MustNewID(locationPrefix)
 	name := gofakeit.DomainName()
 
+	lb := (&LoadBalancerBuilder{}).MustNew(ctx)
+	port := (&PortBuilder{Name: "port80", LoadBalancerID: lb.ID, Number: 80}).MustNew(ctx)
+
 	testCases := []struct {
 		TestName   string
 		Input      graphclient.CreateLoadBalancerInput
@@ -120,6 +123,11 @@ func TestCreate_loadBalancer(t *testing.T) {
 			TestName: "fails to create loadbalancer with empty locationID",
 			Input:    graphclient.CreateLoadBalancerInput{Name: name, ProviderID: prov.ID, OwnerID: ownerID, LocationID: ""},
 			errorMsg: "value is less than the required length",
+		},
+		{
+			TestName: "fails to create loadbalancer with conflicting port",
+			Input:    graphclient.CreateLoadBalancerInput{Name: name, ProviderID: prov.ID, OwnerID: ownerID, LocationID: locationID, PortIDs: []gidx.PrefixedID{port.ID}},
+			errorMsg: "is already connected to a different load_balancer_id",
 		},
 	}
 

--- a/internal/graphapi/loadbalancer_test.go
+++ b/internal/graphapi/loadbalancer_test.go
@@ -125,7 +125,7 @@ func TestCreate_loadBalancer(t *testing.T) {
 			errorMsg: "value is less than the required length",
 		},
 		{
-			TestName: "fails to create loadbalancer with conflicting port",
+			TestName: "fails to create loadbalancer with another loadbalancer's port",
 			Input:    graphclient.CreateLoadBalancerInput{Name: name, ProviderID: prov.ID, OwnerID: ownerID, LocationID: locationID, PortIDs: []gidx.PrefixedID{port.ID}},
 			errorMsg: "is already connected to a different load_balancer_id",
 		},
@@ -171,6 +171,8 @@ func TestUpdate_loadBalancer(t *testing.T) {
 	ctx = context.WithValue(ctx, permissions.CheckerCtxKey, permissions.DefaultAllowChecker)
 
 	lb := (&LoadBalancerBuilder{}).MustNew(ctx)
+	lb2 := (&LoadBalancerBuilder{}).MustNew(ctx)
+	port := (&PortBuilder{LoadBalancerID: lb2.ID}).MustNew(ctx)
 	updateName := gofakeit.DomainName()
 	emptyName := ""
 
@@ -194,6 +196,11 @@ func TestUpdate_loadBalancer(t *testing.T) {
 			TestName: "fails to update name to empty",
 			Input:    graphclient.UpdateLoadBalancerInput{Name: &emptyName},
 			errorMsg: "value is less than the required length",
+		},
+		{
+			TestName: "fails to update loadbalancer with another loadbalancer's port",
+			Input:    graphclient.UpdateLoadBalancerInput{AddPortIDs: []gidx.PrefixedID{port.ID}},
+			errorMsg: "is already connected to a different load_balancer_id",
 		},
 	}
 

--- a/internal/graphapi/pool.resolvers.go
+++ b/internal/graphapi/pool.resolvers.go
@@ -10,13 +10,14 @@ import (
 	"fmt"
 
 	"github.com/labstack/gommon/log"
+	"go.infratographer.com/permissions-api/pkg/permissions"
+	"go.infratographer.com/x/gidx"
+
 	"go.infratographer.com/load-balancer-api/internal/ent/generated"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/loadbalancer"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/origin"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/port"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/predicate"
-	"go.infratographer.com/permissions-api/pkg/permissions"
-	"go.infratographer.com/x/gidx"
 )
 
 // LoadBalancerPoolCreate is the resolver for the LoadBalancerPoolCreate field.
@@ -31,7 +32,7 @@ func (r *mutationResolver) LoadBalancerPoolCreate(ctx context.Context, input gen
 	}
 
 	if len(ids) < len(input.PortIDs) {
-		return nil, ErrOwnerConflict
+		return nil, ErrPortNotFound
 	}
 
 	for _, portId := range input.PortIDs {
@@ -65,7 +66,7 @@ func (r *mutationResolver) LoadBalancerPoolUpdate(ctx context.Context, id gidx.P
 	}
 
 	if len(ids) < len(input.AddPortIDs) {
-		return nil, ErrOwnerConflict
+		return nil, ErrPortNotFound
 	}
 
 	for _, portId := range input.AddPortIDs {

--- a/internal/graphapi/pool.resolvers.go
+++ b/internal/graphapi/pool.resolvers.go
@@ -29,7 +29,7 @@ func (r *mutationResolver) LoadBalancerPoolCreate(ctx context.Context, input gen
 			return nil, err
 		}
 
-		if err := permissions.CheckAccess(ctx, port.LoadBalancerID, actionLoadBalancerUpdate); err != nil {
+		if err := permissions.CheckAccess(ctx, port.LoadBalancerID, actionLoadBalancerGet); err != nil {
 			return nil, err
 		}
 

--- a/internal/graphapi/pool_test.go
+++ b/internal/graphapi/pool_test.go
@@ -146,7 +146,7 @@ func TestMutate_PoolCreate(t *testing.T) {
 				OwnerID:  ownerID,
 				PortIDs:  []gidx.PrefixedID{port.ID},
 			},
-			errorMsg: "conflicting ownership",
+			errorMsg: "one or more ports not found",
 		},
 	}
 
@@ -233,7 +233,7 @@ func TestMutate_PoolUpdate(t *testing.T) {
 				Name:       newString("ImaPool"),
 				AddPortIDs: []gidx.PrefixedID{port.ID},
 			},
-			errorMsg: "conflicting ownership",
+			errorMsg: "one or more ports not found",
 		},
 	}
 

--- a/internal/graphapi/pool_test.go
+++ b/internal/graphapi/pool_test.go
@@ -91,8 +91,6 @@ func TestMutate_PoolCreate(t *testing.T) {
 
 	lb := (&LoadBalancerBuilder{}).MustNew(ctx)
 	port := (&PortBuilder{Name: "port80", LoadBalancerID: lb.ID, Number: 80}).MustNew(ctx)
-	pool1 := (&PoolBuilder{Protocol: "tcp"}).MustNew(ctx)
-	origin := (&OriginBuilder{PoolID: pool1.ID}).MustNew(ctx)
 
 	testCases := []struct {
 		TestName     string
@@ -150,16 +148,6 @@ func TestMutate_PoolCreate(t *testing.T) {
 			},
 			errorMsg: "conflicting ownership",
 		},
-		{
-			TestName: "origin from another pool",
-			Input: graphclient.CreateLoadBalancerPoolInput{
-				Name:      "pooly",
-				Protocol:  graphclient.LoadBalancerPoolProtocolUDP,
-				OwnerID:   ownerID,
-				OriginIDs: []gidx.PrefixedID{origin.ID},
-			},
-			errorMsg: "is already connected to a different pool_id",
-		},
 	}
 
 	for _, tt := range testCases {
@@ -199,10 +187,8 @@ func TestMutate_PoolUpdate(t *testing.T) {
 	ctx = context.WithValue(ctx, permissions.CheckerCtxKey, permissions.DefaultAllowChecker)
 
 	pool1 := (&PoolBuilder{Protocol: "tcp"}).MustNew(ctx)
-	pool2 := (&PoolBuilder{Protocol: "tcp"}).MustNew(ctx)
 	lb := (&LoadBalancerBuilder{}).MustNew(ctx)
 	port := (&PortBuilder{LoadBalancerID: lb.ID}).MustNew(ctx)
-	origin := (&OriginBuilder{PoolID: pool2.ID}).MustNew(ctx)
 	updateProtocolUDP := graphclient.LoadBalancerPoolProtocolUDP
 
 	testCases := []struct {
@@ -248,14 +234,6 @@ func TestMutate_PoolUpdate(t *testing.T) {
 				AddPortIDs: []gidx.PrefixedID{port.ID},
 			},
 			errorMsg: "conflicting ownership",
-		},
-		{
-			TestName: "fails to update pool with another pool's origin",
-			Input: graphclient.UpdateLoadBalancerPoolInput{
-				Name:         newString("ImaPool"),
-				AddOriginIDs: []gidx.PrefixedID{origin.ID},
-			},
-			errorMsg: "is already connected to a different pool_id",
 		},
 	}
 

--- a/internal/graphapi/pool_test.go
+++ b/internal/graphapi/pool_test.go
@@ -89,6 +89,9 @@ func TestMutate_PoolCreate(t *testing.T) {
 
 	ownerID := gidx.MustNewID(ownerPrefix)
 
+	lb := (&LoadBalancerBuilder{}).MustNew(ctx)
+	port := (&PortBuilder{Name: "port80", LoadBalancerID: lb.ID, Number: 80}).MustNew(ctx)
+
 	testCases := []struct {
 		TestName     string
 		Input        graphclient.CreateLoadBalancerPoolInput
@@ -134,6 +137,16 @@ func TestMutate_PoolCreate(t *testing.T) {
 				OwnerID:  ownerID,
 			},
 			errorMsg: "validator failed",
+		},
+		{
+			TestName: "invalid port",
+			Input: graphclient.CreateLoadBalancerPoolInput{
+				Name:     "",
+				Protocol: graphclient.LoadBalancerPoolProtocolUDP,
+				OwnerID:  ownerID,
+				PortIDs:  []gidx.PrefixedID{port.ID},
+			},
+			errorMsg: "conflicting ownership",
 		},
 	}
 

--- a/internal/graphapi/port.resolvers.go
+++ b/internal/graphapi/port.resolvers.go
@@ -25,7 +25,7 @@ func (r *mutationResolver) LoadBalancerPortCreate(ctx context.Context, input gen
 	}
 
 	for _, poolId := range input.PoolIDs {
-		if err := permissions.CheckAccess(ctx, poolId, actionLoadBalancerPoolUpdate); err != nil {
+		if err := permissions.CheckAccess(ctx, poolId, actionLoadBalancerPoolGet); err != nil {
 			return nil, err
 		}
 
@@ -68,7 +68,7 @@ func (r *mutationResolver) LoadBalancerPortUpdate(ctx context.Context, id gidx.P
 	}
 
 	for _, poolId := range input.AddPoolIDs {
-		if err := permissions.CheckAccess(ctx, poolId, actionLoadBalancerPoolUpdate); err != nil {
+		if err := permissions.CheckAccess(ctx, poolId, actionLoadBalancerPoolGet); err != nil {
 			return nil, err
 		}
 

--- a/internal/graphapi/port.resolvers.go
+++ b/internal/graphapi/port.resolvers.go
@@ -8,10 +8,11 @@ import (
 	"context"
 	"strings"
 
-	"go.infratographer.com/load-balancer-api/internal/ent/generated"
-	"go.infratographer.com/load-balancer-api/internal/ent/generated/pool"
 	"go.infratographer.com/permissions-api/pkg/permissions"
 	"go.infratographer.com/x/gidx"
+
+	"go.infratographer.com/load-balancer-api/internal/ent/generated"
+	"go.infratographer.com/load-balancer-api/internal/ent/generated/pool"
 )
 
 // LoadBalancerPortCreate is the resolver for the loadBalancerPortCreate field.
@@ -31,7 +32,7 @@ func (r *mutationResolver) LoadBalancerPortCreate(ctx context.Context, input gen
 	}
 
 	if len(ids) < len(input.PoolIDs) {
-		return nil, ErrOwnerConflict
+		return nil, ErrPoolNotFound
 	}
 
 	for _, poolId := range input.PoolIDs {
@@ -74,7 +75,7 @@ func (r *mutationResolver) LoadBalancerPortUpdate(ctx context.Context, id gidx.P
 	}
 
 	if len(ids) < len(input.AddPoolIDs) {
-		return nil, ErrOwnerConflict
+		return nil, ErrPoolNotFound
 	}
 
 	for _, poolId := range input.AddPoolIDs {

--- a/internal/graphapi/port_test.go
+++ b/internal/graphapi/port_test.go
@@ -106,7 +106,7 @@ func TestCreate_LoadbalancerPort(t *testing.T) {
 			errorMsg: "port number restricted",
 		},
 		{
-			TestName: "fails to create loadbalancer port with someone else's pool",
+			TestName: "fails to create loadbalancer port with pool with conflicting OwnerID",
 			Input: graphclient.CreateLoadBalancerPortInput{
 				Name:           "lb-port",
 				LoadBalancerID: lb.ID,
@@ -225,7 +225,7 @@ func TestUpdate_LoadbalancerPort(t *testing.T) {
 			errorMsg: "value out of range",
 		},
 		{
-			TestName: "fails to update loadbalancer port with someone else's pool",
+			TestName: "fails to update loadbalancer port with pool with conflicting OwnerID",
 			Input: graphclient.UpdateLoadBalancerPortInput{
 				AddPoolIDs: []gidx.PrefixedID{poolBad.ID},
 			},

--- a/internal/graphapi/port_test.go
+++ b/internal/graphapi/port_test.go
@@ -113,7 +113,7 @@ func TestCreate_LoadbalancerPort(t *testing.T) {
 				Number:         1234,
 				PoolIDs:        []gidx.PrefixedID{poolBad.ID},
 			},
-			errorMsg: "conflicting ownership",
+			errorMsg: "one or more pools not found",
 		},
 	}
 
@@ -229,7 +229,7 @@ func TestUpdate_LoadbalancerPort(t *testing.T) {
 			Input: graphclient.UpdateLoadBalancerPortInput{
 				AddPoolIDs: []gidx.PrefixedID{poolBad.ID},
 			},
-			errorMsg: "conflicting ownership",
+			errorMsg: "one or more pools not found",
 		},
 	}
 


### PR DESCRIPTION
Adds resolver validations for attaching ports to pools and pools to ports.
Previous PR was too lengthy so splitting up the api change and the validation.