### PR TITLE
Remove ports as param for loadbalancer mutations

### DIFF
--- a/internal/ent/generated/gql_mutation_input.go
+++ b/internal/ent/generated/gql_mutation_input.go
@@ -26,7 +26,6 @@ type CreateLoadBalancerInput struct {
 	Name       string
 	OwnerID    gidx.PrefixedID
 	LocationID gidx.PrefixedID
-	PortIDs    []gidx.PrefixedID
 	ProviderID gidx.PrefixedID
 }
 
@@ -35,9 +34,6 @@ func (i *CreateLoadBalancerInput) Mutate(m *LoadBalancerMutation) {
 	m.SetName(i.Name)
 	m.SetOwnerID(i.OwnerID)
 	m.SetLocationID(i.LocationID)
-	if v := i.PortIDs; len(v) > 0 {
-		m.AddPortIDs(v...)
-	}
 	m.SetProviderID(i.ProviderID)
 }
 
@@ -49,25 +45,13 @@ func (c *LoadBalancerCreate) SetInput(i CreateLoadBalancerInput) *LoadBalancerCr
 
 // UpdateLoadBalancerInput represents a mutation input for updating loadbalancers.
 type UpdateLoadBalancerInput struct {
-	Name          *string
-	ClearPorts    bool
-	AddPortIDs    []gidx.PrefixedID
-	RemovePortIDs []gidx.PrefixedID
+	Name *string
 }
 
 // Mutate applies the UpdateLoadBalancerInput on the LoadBalancerMutation builder.
 func (i *UpdateLoadBalancerInput) Mutate(m *LoadBalancerMutation) {
 	if v := i.Name; v != nil {
 		m.SetName(*v)
-	}
-	if i.ClearPorts {
-		m.ClearPorts()
-	}
-	if v := i.AddPortIDs; len(v) > 0 {
-		m.AddPortIDs(v...)
-	}
-	if v := i.RemovePortIDs; len(v) > 0 {
-		m.RemovePortIDs(v...)
 	}
 }
 

--- a/internal/ent/schema/loadbalancer.go
+++ b/internal/ent/schema/loadbalancer.go
@@ -86,6 +86,8 @@ func (LoadBalancer) Edges() []ent.Edge {
 			Ref("load_balancer").
 			Annotations(
 				entgql.RelayConnection(),
+				entgql.Skip(entgql.SkipMutationCreateInput),
+				entgql.Skip(entgql.SkipMutationUpdateInput),
 			),
 		edge.To("provider", Provider.Type).
 			Unique().

--- a/internal/graphapi/gen_server.go
+++ b/internal/graphapi/gen_server.go
@@ -1491,7 +1491,6 @@ input CreateLoadBalancerInput {
   ownerID: ID!
   """The ID for the location of this load balancer."""
   locationID: ID!
-  portIDs: [ID!]
   providerID: ID!
 }
 """
@@ -2174,9 +2173,6 @@ scalar Time
 input UpdateLoadBalancerInput {
   """The name of the load balancer."""
   name: String
-  addPortIDs: [ID!]
-  removePortIDs: [ID!]
-  clearPorts: Boolean
 }
 """
 UpdateLoadBalancerOriginInput is used for update LoadBalancerOrigin object.
@@ -11956,7 +11952,7 @@ func (ec *executionContext) unmarshalInputCreateLoadBalancerInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "ownerID", "locationID", "portIDs", "providerID"}
+	fieldsInOrder := [...]string{"name", "ownerID", "locationID", "providerID"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -11990,15 +11986,6 @@ func (ec *executionContext) unmarshalInputCreateLoadBalancerInput(ctx context.Co
 				return it, err
 			}
 			it.LocationID = data
-		case "portIDs":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("portIDs"))
-			data, err := ec.unmarshalOID2ᚕgoᚗinfratographerᚗcomᚋxᚋgidxᚐPrefixedIDᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.PortIDs = data
 		case "providerID":
 			var err error
 
@@ -14814,7 +14801,7 @@ func (ec *executionContext) unmarshalInputUpdateLoadBalancerInput(ctx context.Co
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "addPortIDs", "removePortIDs", "clearPorts"}
+	fieldsInOrder := [...]string{"name"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -14830,33 +14817,6 @@ func (ec *executionContext) unmarshalInputUpdateLoadBalancerInput(ctx context.Co
 				return it, err
 			}
 			it.Name = data
-		case "addPortIDs":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("addPortIDs"))
-			data, err := ec.unmarshalOID2ᚕgoᚗinfratographerᚗcomᚋxᚋgidxᚐPrefixedIDᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.AddPortIDs = data
-		case "removePortIDs":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("removePortIDs"))
-			data, err := ec.unmarshalOID2ᚕgoᚗinfratographerᚗcomᚋxᚋgidxᚐPrefixedIDᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.RemovePortIDs = data
-		case "clearPorts":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("clearPorts"))
-			data, err := ec.unmarshalOBoolean2bool(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.ClearPorts = data
 		}
 	}
 

--- a/internal/graphapi/port.resolvers.go
+++ b/internal/graphapi/port.resolvers.go
@@ -8,11 +8,10 @@ import (
 	"context"
 	"strings"
 
-	"go.infratographer.com/permissions-api/pkg/permissions"
-	"go.infratographer.com/x/gidx"
-
 	"go.infratographer.com/load-balancer-api/internal/ent/generated"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/pool"
+	"go.infratographer.com/permissions-api/pkg/permissions"
+	"go.infratographer.com/x/gidx"
 )
 
 // LoadBalancerPortCreate is the resolver for the loadBalancerPortCreate field.

--- a/internal/graphclient/gen_models.go
+++ b/internal/graphclient/gen_models.go
@@ -40,9 +40,8 @@ type CreateLoadBalancerInput struct {
 	// The ID for the owner for this load balancer.
 	OwnerID gidx.PrefixedID `json:"ownerID"`
 	// The ID for the location of this load balancer.
-	LocationID gidx.PrefixedID   `json:"locationID"`
-	PortIDs    []gidx.PrefixedID `json:"portIDs,omitempty"`
-	ProviderID gidx.PrefixedID   `json:"providerID"`
+	LocationID gidx.PrefixedID `json:"locationID"`
+	ProviderID gidx.PrefixedID `json:"providerID"`
 }
 
 // CreateLoadBalancerOriginInput is used for create LoadBalancerOrigin object.
@@ -746,10 +745,7 @@ func (ResourceOwner) IsEntity() {}
 // Input information to update a load balancer.
 type UpdateLoadBalancerInput struct {
 	// The name of the load balancer.
-	Name          *string           `json:"name,omitempty"`
-	AddPortIDs    []gidx.PrefixedID `json:"addPortIDs,omitempty"`
-	RemovePortIDs []gidx.PrefixedID `json:"removePortIDs,omitempty"`
-	ClearPorts    *bool             `json:"clearPorts,omitempty"`
+	Name *string `json:"name,omitempty"`
 }
 
 // UpdateLoadBalancerOriginInput is used for update LoadBalancerOrigin object.

--- a/internal/graphclient/schema/schema.graphql
+++ b/internal/graphclient/schema/schema.graphql
@@ -19,7 +19,6 @@ input CreateLoadBalancerInput {
 	ownerID: ID!
 	"""The ID for the location of this load balancer."""
 	locationID: ID!
-	portIDs: [ID!]
 	providerID: ID!
 }
 """
@@ -923,9 +922,6 @@ scalar Time
 input UpdateLoadBalancerInput {
 	"""The name of the load balancer."""
 	name: String
-	addPortIDs: [ID!]
-	removePortIDs: [ID!]
-	clearPorts: Boolean
 }
 """
 UpdateLoadBalancerOriginInput is used for update LoadBalancerOrigin object.

--- a/schema.graphql
+++ b/schema.graphql
@@ -7,7 +7,6 @@ input CreateLoadBalancerInput {
 	ownerID: ID!
 	"""The ID for the location of this load balancer."""
 	locationID: ID!
-	portIDs: [ID!]
 	providerID: ID!
 }
 """
@@ -910,9 +909,6 @@ scalar Time
 input UpdateLoadBalancerInput {
 	"""The name of the load balancer."""
 	name: String
-	addPortIDs: [ID!]
-	removePortIDs: [ID!]
-	clearPorts: Boolean
 }
 """
 UpdateLoadBalancerOriginInput is used for update LoadBalancerOrigin object.

--- a/schema/ent.graphql
+++ b/schema/ent.graphql
@@ -8,7 +8,6 @@ input CreateLoadBalancerInput {
   ownerID: ID!
   """The ID for the location of this load balancer."""
   locationID: ID!
-  portIDs: [ID!]
   providerID: ID!
 }
 """
@@ -691,9 +690,6 @@ scalar Time
 input UpdateLoadBalancerInput {
   """The name of the load balancer."""
   name: String
-  addPortIDs: [ID!]
-  removePortIDs: [ID!]
-  clearPorts: Boolean
 }
 """
 UpdateLoadBalancerOriginInput is used for update LoadBalancerOrigin object.


### PR DESCRIPTION
Loadbalancers and ports have a 1:m relationship and so for 
- lb creation: lb needs to be created before ports can be made
- lb update: ports only exist as part of a lb so doesnt make sense to add ports from other lbs to a lb

Thus we should remove this api param since it is redundant.