### PR TITLE
Adds ability to limit number of loadbalancers an owner can create

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -116,6 +116,8 @@ func writePidFile(pidFile string) error {
 func serve(ctx context.Context) error {
 	var resolverOpts []graphapi.Option
 
+	config.AppConfig.LoadBalancerLimit = viper.GetInt("load-balancer-limit")
+
 	if serveDevMode {
 		enablePlayground = true
 		config.AppConfig.Logging.Debug = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,17 +17,18 @@ import (
 
 // AppConfig stores all the config values for our application
 var AppConfig struct {
-	OIDC            echojwtx.AuthConfig `mapstructure:"oidc"`
-	OIDCClient      OIDCClientConfig    `mapstructure:"oidc"`
-	CRDB            crdbx.Config
-	Logging         loggingx.Config
-	Server          echox.Config
-	Tracing         otelx.Config
-	Events          events.Config
-	Permissions     permissions.Config
-	Metadata        MetadataConfig
-	RestrictedPorts []int
-	Supergraph      SupergraphConfig
+	OIDC              echojwtx.AuthConfig `mapstructure:"oidc"`
+	OIDCClient        OIDCClientConfig    `mapstructure:"oidc"`
+	CRDB              crdbx.Config
+	Logging           loggingx.Config
+	Server            echox.Config
+	Tracing           otelx.Config
+	Events            events.Config
+	Permissions       permissions.Config
+	LoadBalancerLimit int
+	Metadata          MetadataConfig
+	RestrictedPorts   []int
+	Supergraph        SupergraphConfig
 }
 
 // MetadataConfig stores the configuration for metadata

--- a/internal/graphapi/errors.go
+++ b/internal/graphapi/errors.go
@@ -17,4 +17,7 @@ var (
 
 	// ErrInternalServerError is returned when an internal error occurs.
 	ErrInternalServerError = errors.New("internal server error")
+
+	// ErrLoadBalancerLimitReached is returned when the load balancer limit has been reached for an owner.
+	ErrLoadBalancerLimitReached = errors.New("load balancer limit reached")
 )

--- a/internal/graphapi/loadbalancer_test.go
+++ b/internal/graphapi/loadbalancer_test.go
@@ -173,30 +173,23 @@ func TestCreate_loadBalancer_limit(t *testing.T) {
 	locationID := gidx.MustNewID(locationPrefix)
 	name := gofakeit.DomainName()
 
+	config.AppConfig.LoadBalancerLimit = 3
+
 	testCases := []struct {
 		TestName string
 		lbCount  int
-		lbLimit  int
 		Input    graphclient.CreateLoadBalancerInput
 		errorMsg string
 	}{
 		{
-			TestName: "creates loadbalancers - no limit",
-			Input:    graphclient.CreateLoadBalancerInput{Name: name, ProviderID: prov.ID, OwnerID: gidx.MustNewID(ownerPrefix), LocationID: locationID},
-			lbCount:  2,
-			lbLimit:  0,
-		},
-		{
 			TestName: "creates loadbalancers - under limit",
 			Input:    graphclient.CreateLoadBalancerInput{Name: name, ProviderID: prov.ID, OwnerID: gidx.MustNewID(ownerPrefix), LocationID: locationID},
 			lbCount:  2,
-			lbLimit:  3,
 		},
 		{
 			TestName: "fails to create loadbalancers - over limit",
 			Input:    graphclient.CreateLoadBalancerInput{Name: name, ProviderID: prov.ID, OwnerID: gidx.MustNewID(ownerPrefix), LocationID: locationID},
 			lbCount:  5,
-			lbLimit:  2,
 			errorMsg: "load balancer limit reached",
 		},
 	}
@@ -206,7 +199,6 @@ func TestCreate_loadBalancer_limit(t *testing.T) {
 			tt := tt
 			t.Parallel()
 			var err error
-			config.AppConfig.LoadBalancerLimit = tt.lbLimit
 
 			for i := 1; i < tt.lbCount; i++ {
 				_, err = graphTestClient().LoadBalancerCreate(ctx, tt.Input)


### PR DESCRIPTION
##What

This PR adds the ability to limit the number of load balancers a given resource owner can create/ have created at a given point of time. If the limit is not set, it will default to 0 and will not have any impact. If it is set, an error will be return on the X number of load balancer created letting the user know they have exceeded the limit.

## Why

Loadbalancers are the resource that is likely to consume resources in a given environment (deployed to a cluster to soak up CPU/Memory, potentially configuring IP addresses), so we want to give some minimal configuration that would allow an operator to safely limit that in their environment.