### PR TITLE
Add node Metadata fragment query to client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -64,13 +64,13 @@ func (c Client) GetLoadBalancer(ctx context.Context, id string) (*LoadBalancer, 
 	return &q.LoadBalancer, nil
 }
 
-// NodeMetadata returns the metadata-api subgraph node for a load balancer
-// Once a load balancer is deleted, it is fully removed from load-balancer-api.
-// There are no soft-deletes due to permissions complications.
-// However, it's metadata remains to query via the node-resolver subgraph.
+// NodeMetadata return the metadata-api subgraph node for a load balancer.
+// Once a load balancer is deleted, it is gone. There are no soft-deletes.
+// However, it's metadata remains to query via the node-resolver metadata-api subgraph.
+// TODO: Move this to a supergraph client
 func (c Client) NodeMetadata(ctx context.Context, id string) (*Metadata, error) {
-	//	query Test {
-	//	  node(id:"loadbal-RelHb0FU59uEjlhtT7MAl") {
+	//	query {
+	//	  node(id:"loadbal-example") {
 	//	    ... on MetadataNode {
 	//	      metadata {
 	//	        statuses {
@@ -85,7 +85,6 @@ func (c Client) NodeMetadata(ctx context.Context, id string) (*Metadata, error) 
 	//	    }
 	//	  }
 	//	}
-
 	_, err := gidx.Parse(id)
 	if err != nil {
 		return nil, err
@@ -100,7 +99,7 @@ func (c Client) NodeMetadata(ctx context.Context, id string) (*Metadata, error) 
 		return nil, translateGQLErr(err)
 	}
 
-	if q.MetadataNode.Metadata.Statuses.TotalCount == 0 {
+	if q.MetadataNode.Metadata.ID == "" || q.MetadataNode.Metadata.Statuses.TotalCount == 0 {
 		return nil, ErrMetadataStatusNotFound
 	}
 

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -16,4 +16,10 @@ var (
 
 	// ErrHTTPError returned when the http response is an error
 	ErrHTTPError = errors.New("loadbalancer api http error")
+
+	// ErrInternalServerError returned when the server returns an internal server error
+	ErrInternalServerError = errors.New("internal server error")
+
+	// ErrMetadataStatusNotFound returned when the status data is invalid
+	ErrMetadataStatusNotFound = errors.New("metadata status not found")
 )

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -96,7 +96,8 @@ type MetadataStatusEdges struct {
 
 // MetadataStatuses is a struct that represents the Metadata statuses GraphQL type
 type MetadataStatuses struct {
-	Edges []MetadataStatusEdges `graphql:"edges" json:"edges"`
+	TotalCount int                   `graphql:"totalCount" json:"totalCount"`
+	Edges      []MetadataStatusEdges `graphql:"edges" json:"edges"`
 }
 
 // Metadata is a struct that represents the metadata GraphQL type
@@ -104,6 +105,21 @@ type Metadata struct {
 	ID       string           `graphql:"id" json:"id"`
 	NodeID   string           `graphql:"nodeID" json:"nodeID"`
 	Statuses MetadataStatuses `graphql:"statuses" json:"statuses"`
+}
+
+// MetadataNodeFragment is a struct that represents the MetadataNodeFragment GraphQL fragment
+type MetadataNodeFragment struct {
+	Metadata Metadata `graphql:"metadata" json:"metadata"`
+}
+
+// MetadataNode is a struct that represents the MetadataNode GraphQL type
+type MetadataNode struct {
+	MetadataNodeFragment `graphql:"... on MetadataNode"`
+}
+
+// GetMetadataNode is a struct that represents the node-resolver subgraph query
+type GetMetadataNode struct {
+	MetadataNode MetadataNode `graphql:"node(id: $id)"`
 }
 
 // Readable version of the above:

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -28,15 +28,17 @@ type LoadBalancerStatus struct {
 
 // GetLoadbalancerStatus returns the status of a load balancer
 func GetLoadbalancerStatus(metadataStatuses client.MetadataStatuses, statusNamespaceID gidx.PrefixedID) (*LoadBalancerStatus, error) {
-	for _, s := range metadataStatuses.Edges {
-		if s.Node.StatusNamespaceID == statusNamespaceID.String() {
-			status := &LoadBalancerStatus{}
+	if metadataStatuses.TotalCount > 0 {
+		for _, s := range metadataStatuses.Edges {
+			if s.Node.StatusNamespaceID == statusNamespaceID.String() {
+				status := &LoadBalancerStatus{}
 
-			if err := json.Unmarshal(s.Node.Data, status); err != nil {
-				return nil, fmt.Errorf("%w: %s", ErrInvalidStatusData, err)
+				if err := json.Unmarshal(s.Node.Data, status); err != nil {
+					return nil, fmt.Errorf("%w: %s", ErrInvalidStatusData, err)
+				}
+
+				return status, nil
 			}
-
-			return status, nil
 		}
 	}
 

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -13,6 +13,7 @@ import (
 func TestGetLoadbalancerStatus(t *testing.T) {
 	t.Run("valid status", func(t *testing.T) {
 		statuses := client.MetadataStatuses{
+			TotalCount: 2,
 			Edges: []client.MetadataStatusEdges{
 				{
 					Node: client.MetadataStatusNode{
@@ -36,6 +37,7 @@ func TestGetLoadbalancerStatus(t *testing.T) {
 
 	t.Run("bad json data", func(t *testing.T) {
 		statuses := client.MetadataStatuses{
+			TotalCount: 1,
 			Edges: []client.MetadataStatusEdges{
 				{
 					Node: client.MetadataStatusNode{
@@ -54,7 +56,8 @@ func TestGetLoadbalancerStatus(t *testing.T) {
 
 	t.Run("status not found", func(t *testing.T) {
 		statuses := client.MetadataStatuses{
-			Edges: []client.MetadataStatusEdges{},
+			TotalCount: 0,
+			Edges:      []client.MetadataStatusEdges{},
 		}
 
 		status, err := GetLoadbalancerStatus(statuses, "metasns-loadbalancer-status")
@@ -65,6 +68,7 @@ func TestGetLoadbalancerStatus(t *testing.T) {
 
 	t.Run("no status data", func(t *testing.T) {
 		statuses := client.MetadataStatuses{
+			TotalCount: 1,
 			Edges: []client.MetadataStatusEdges{
 				{
 					Node: client.MetadataStatusNode{


### PR DESCRIPTION
# Summary

Query supergraph `node(id: "")` to obtain a loadbalancer's node `metadata` from the [metadata-api](https://github.com/infratographer/metadata-api) subgraph

```
query {
  node(id: "loadbal-example") {
    ... on MetadataNode {
      metadata {
        statuses {
          totalCount
          edges {
            node {
              data
            }
          }
        }
      }
    }
  }
}
```