### PR TITLE
Update metadata integration

### DIFF
--- a/chart/load-balancer-api/templates/deployment.yaml
+++ b/chart/load-balancer-api/templates/deployment.yaml
@@ -74,6 +74,9 @@ spec:
           {{- end }}
           {{- end }}
           envFrom:
+          {{- if .Values.api.extraEnvFrom }}
+            {{- toYaml .Values.api.extraEnvFrom | nindent 12 }}
+          {{- end }}
           {{- if .Values.api.db.uriSecret }}
             - secretRef:
                 name: {{ .Values.api.db.uriSecret }}

--- a/chart/load-balancer-api/values.yaml
+++ b/chart/load-balancer-api/values.yaml
@@ -34,6 +34,7 @@ api:
   listenPort: 7608
   extraLabels: {}
   extraAnnotations: {}
+  extraEnvFrom: {}
   extraEnvVars: []
   #- value: "postgresql://user@my-db-server:26257/load_balancer_api"
   #  name: LOADBALANCERAPI_CRDB_URI

--- a/internal/graphapi/origin.resolvers.go
+++ b/internal/graphapi/origin.resolvers.go
@@ -7,13 +7,14 @@ package graphapi
 import (
 	"context"
 
+	"go.infratographer.com/permissions-api/pkg/permissions"
+	"go.infratographer.com/x/gidx"
+
 	"go.infratographer.com/load-balancer-api/internal/ent/generated"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/origin"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/pool"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/port"
 	"go.infratographer.com/load-balancer-api/pkg/metadata"
-	"go.infratographer.com/permissions-api/pkg/permissions"
-	"go.infratographer.com/x/gidx"
 )
 
 // LoadBalancerOriginCreate is the resolver for the loadBalancerOriginCreate field.
@@ -57,7 +58,6 @@ func (r *mutationResolver) LoadBalancerOriginCreate(ctx context.Context, input g
 		for _, p := range ports {
 			if err := r.LoadBalancerStatusUpdate(ctx, p.LoadBalancerID, status); err != nil {
 				logger.Errorw("failed to update loadbalancer metadata status", "error", err, "loadbalancerID", p.LoadBalancerID)
-				return nil, ErrInternalServerError
 			}
 		}
 	}
@@ -105,7 +105,6 @@ func (r *mutationResolver) LoadBalancerOriginUpdate(ctx context.Context, id gidx
 		for _, p := range ports {
 			if err := r.LoadBalancerStatusUpdate(ctx, p.LoadBalancerID, status); err != nil {
 				logger.Errorw("failed to update loadbalancer metadata status", "error", err, "loadbalancerID", p.LoadBalancerID)
-				return nil, ErrInternalServerError
 			}
 		}
 	}
@@ -148,7 +147,6 @@ func (r *mutationResolver) LoadBalancerOriginDelete(ctx context.Context, id gidx
 		for _, p := range ports {
 			if err := r.LoadBalancerStatusUpdate(ctx, p.LoadBalancerID, status); err != nil {
 				logger.Errorw("failed to update loadbalancer metadata status", "error", err, "loadbalancerID", p.LoadBalancerID)
-				return nil, ErrInternalServerError
 			}
 		}
 	}

--- a/internal/graphapi/pool.resolvers.go
+++ b/internal/graphapi/pool.resolvers.go
@@ -8,6 +8,10 @@ import (
 	"context"
 	"database/sql"
 
+	"go.infratographer.com/permissions-api/pkg/permissions"
+	"go.infratographer.com/x/gidx"
+	"golang.org/x/exp/slices"
+
 	"go.infratographer.com/load-balancer-api/internal/ent/generated"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/loadbalancer"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/origin"
@@ -15,9 +19,6 @@ import (
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/port"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/predicate"
 	"go.infratographer.com/load-balancer-api/pkg/metadata"
-	"go.infratographer.com/permissions-api/pkg/permissions"
-	"go.infratographer.com/x/gidx"
-	"golang.org/x/exp/slices"
 )
 
 // LoadBalancerPoolCreate is the resolver for the LoadBalancerPoolCreate field.
@@ -70,7 +71,6 @@ func (r *mutationResolver) LoadBalancerPoolCreate(ctx context.Context, input gen
 		status := &metadata.LoadBalancerStatus{State: metadata.LoadBalancerStateUpdating}
 		if err := r.LoadBalancerStatusUpdate(ctx, port.LoadBalancerID, status); err != nil {
 			logger.Errorw("failed to update loadbalancer metadata status", "error", err, "loadbalancerID", port.LoadBalancerID)
-			return nil, ErrInternalServerError
 		}
 	}
 
@@ -137,7 +137,6 @@ func (r *mutationResolver) LoadBalancerPoolUpdate(ctx context.Context, id gidx.P
 		status := &metadata.LoadBalancerStatus{State: metadata.LoadBalancerStateUpdating}
 		if err := r.LoadBalancerStatusUpdate(ctx, port.LoadBalancerID, status); err != nil {
 			logger.Errorw("failed to update loadbalancer metadata status", "error", err, "loadbalancerID", port.LoadBalancerID)
-			return nil, ErrInternalServerError
 		}
 	}
 
@@ -215,7 +214,6 @@ func (r *mutationResolver) LoadBalancerPoolDelete(ctx context.Context, id gidx.P
 			status := &metadata.LoadBalancerStatus{State: metadata.LoadBalancerStateUpdating}
 			if err := r.LoadBalancerStatusUpdate(ctx, p.LoadBalancerID, status); err != nil {
 				logger.Errorw("failed to update loadbalancer metadata status", "error", err, "loadbalancerID", p.LoadBalancerID)
-				return nil, ErrInternalServerError
 			}
 		}
 	}

--- a/internal/graphapi/port.resolvers.go
+++ b/internal/graphapi/port.resolvers.go
@@ -8,11 +8,12 @@ import (
 	"context"
 	"strings"
 
+	"go.infratographer.com/permissions-api/pkg/permissions"
+	"go.infratographer.com/x/gidx"
+
 	"go.infratographer.com/load-balancer-api/internal/ent/generated"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/pool"
 	"go.infratographer.com/load-balancer-api/pkg/metadata"
-	"go.infratographer.com/permissions-api/pkg/permissions"
-	"go.infratographer.com/x/gidx"
 )
 
 // LoadBalancerPortCreate is the resolver for the loadBalancerPortCreate field.
@@ -78,7 +79,6 @@ func (r *mutationResolver) LoadBalancerPortCreate(ctx context.Context, input gen
 	status := &metadata.LoadBalancerStatus{State: metadata.LoadBalancerStateUpdating}
 	if err := r.LoadBalancerStatusUpdate(ctx, lb.ID, status); err != nil {
 		r.logger.Errorw("failed to update loadbalancer metadata status", "error", err, "loadbalancerID", lb.ID)
-		return nil, ErrInternalServerError
 	}
 
 	return &LoadBalancerPortCreatePayload{LoadBalancerPort: p}, nil
@@ -150,7 +150,6 @@ func (r *mutationResolver) LoadBalancerPortUpdate(ctx context.Context, id gidx.P
 	status := &metadata.LoadBalancerStatus{State: metadata.LoadBalancerStateUpdating}
 	if err := r.LoadBalancerStatusUpdate(ctx, lb.ID, status); err != nil {
 		r.logger.Errorw("failed to update loadbalancer metadata status", "error", err, "loadbalancerID", lb.ID)
-		return nil, ErrInternalServerError
 	}
 
 	return &LoadBalancerPortUpdatePayload{LoadBalancerPort: p}, nil
@@ -187,7 +186,6 @@ func (r *mutationResolver) LoadBalancerPortDelete(ctx context.Context, id gidx.P
 	status := &metadata.LoadBalancerStatus{State: metadata.LoadBalancerStateUpdating}
 	if err := r.LoadBalancerStatusUpdate(ctx, p.LoadBalancerID, status); err != nil {
 		r.logger.Errorw("failed to update loadbalancer metadata status", "error", err, "loadbalancerID", p.LoadBalancerID)
-		return nil, ErrInternalServerError
 	}
 
 	return &LoadBalancerPortDeletePayload{DeletedID: id}, nil


### PR DESCRIPTION
# Summary

- [x] Not returning an `internal server error` when there is a failure to update metadata-api with loadbalancer status. Just log the error
- [x] Add `ExtraEnvFrom` to chart deployment

## Testing

### Creating/updating

```
query NodeLB {
  node(id:"loadbal-testing") {
    id
    ... on LoadBalancer {
      metadata {
        statuses {
          totalCount
          edges {
            node {
              data
              metadataID
              source
              namespace{
                id
                name
              }
            }
          }
        }
      }
    }
  }
}
```

```
{
  "data": {
    "node": {
      "id": "loadbal-testing",
      "metadata": {
        "statuses": {
          "totalCount": 2,
          "edges": [
            {
              "node": {
                "data": {
                  "state": "ip-address.assigned"
                },
                "metadataID": "metadat-testing",
                "source": "loadbalancer-provider-haproxy",
                "namespace": {
                  "id": "metasns-testing",
                  "name": "loadbalancer haproxy status namespace"
                }
              }
            },
            {
              "node": {
                "data": {
                  "state": "updating"
                },
                "metadataID": "testing",
                "source": "load-balancer-api",
                "namespace": {
                  "id": "metasns-testing",
                  "name": "loadbalancer haproxy status namespace"
                }
              }
            }
          ]
        }
      }
    }
  }
}
```

### Terminating

```
{
  "data": {
    "node": {
      "id": "loadbal-testing",
      "metadata": {
        "statuses": {
          "totalCount": 2,
          "edges": [
            {
              "node": {
                "data": {
                  "state": "ip-address.unassigned"
                },
                "metadataID": "metadat-testing",
                "source": "loadbalancer-provider-haproxy",
                "namespace": {
                  "id": "metasns-testing",
                  "name": "loadbalancer haproxy status namespace"
                }
              }
            },
            {
              "node": {
                "data": {
                  "state": "terminating"
                },
                "metadataID": "metadat-testing",
                "source": "load-balancer-api",
                "namespace": {
                  "id": "metasns-testing",
                  "name": "loadbalancer haproxy status namespace"
                }
              }
            }
          ]
        }
      }
    }
  }
}
```