### PR TITLE
Check owner permissions in resolvers

### DIFF
--- a/internal/ent/schema/port.go
+++ b/internal/ent/schema/port.go
@@ -58,6 +58,7 @@ func (Port) Fields() []ent.Field {
 			Annotations(
 				entgql.Type("ID"),
 				entgql.Skip(entgql.SkipWhereInput, entgql.SkipMutationUpdateInput),
+				pubsubinfo.EventsHookAdditionalSubject("loadbalancer"),
 			),
 	}
 }

--- a/internal/graphapi/loadbalancer.resolvers.go
+++ b/internal/graphapi/loadbalancer.resolvers.go
@@ -27,7 +27,7 @@ func (r *mutationResolver) LoadBalancerCreate(ctx context.Context, input generat
 	}
 
 	if config.AppConfig.LoadBalancerLimit > 0 {
-		count, err := r.client.LoadBalancer.Query().Where(predicate.LoadBalancer(loadbalancer.OwnerIDEQ(input.OwnerID))).Count(ctx)
+		count, err := r.client.LoadBalancer.Query().Where(loadbalancer.OwnerIDEQ(input.OwnerID)).Count(ctx)
 		if err != nil {
 			r.logger.Errorw("failed to query loadbalancer count", "error", err)
 		}
@@ -64,10 +64,6 @@ func (r *mutationResolver) LoadBalancerUpdate(ctx context.Context, id gidx.Prefi
 		return nil, err
 	}
 
-	if err := permissions.CheckAccess(ctx, id, actionLoadBalancerUpdate); err != nil {
-		return nil, err
-	}
-
 	lb, err := r.client.LoadBalancer.Get(ctx, id)
 	if err != nil {
 		if generated.IsNotFound(err) {
@@ -76,6 +72,10 @@ func (r *mutationResolver) LoadBalancerUpdate(ctx context.Context, id gidx.Prefi
 
 		logger.Errorw("failed to get loadbalancer", "error", err)
 		return nil, ErrInternalServerError
+	}
+
+	if err := permissions.CheckAccess(ctx, lb.OwnerID, actionLoadBalancerUpdate); err != nil {
+		return nil, err
 	}
 
 	lb, err = lb.Update().SetInput(input).Save(ctx)
@@ -105,10 +105,6 @@ func (r *mutationResolver) LoadBalancerDelete(ctx context.Context, id gidx.Prefi
 		return nil, err
 	}
 
-	if err := permissions.CheckAccess(ctx, id, actionLoadBalancerDelete); err != nil {
-		return nil, err
-	}
-
 	lb, err := r.client.LoadBalancer.Get(ctx, id)
 	if err != nil {
 		if generated.IsNotFound(err) {
@@ -117,6 +113,10 @@ func (r *mutationResolver) LoadBalancerDelete(ctx context.Context, id gidx.Prefi
 
 		logger.Errorw("failed to get loadbalancer", "error", err)
 		return nil, ErrInternalServerError
+	}
+
+	if err := permissions.CheckAccess(ctx, lb.OwnerID, actionLoadBalancerDelete); err != nil {
+		return nil, err
 	}
 
 	tx, err := r.client.BeginTx(ctx, &sql.TxOptions{})
@@ -191,10 +191,6 @@ func (r *queryResolver) LoadBalancer(ctx context.Context, id gidx.PrefixedID) (*
 		return nil, err
 	}
 
-	if err := permissions.CheckAccess(ctx, id, actionLoadBalancerGet); err != nil {
-		return nil, err
-	}
-
 	lb, err := r.client.LoadBalancer.Get(ctx, id)
 	if err != nil {
 		if generated.IsNotFound(err) {
@@ -203,6 +199,10 @@ func (r *queryResolver) LoadBalancer(ctx context.Context, id gidx.PrefixedID) (*
 
 		logger.Errorw("failed to get loadbalancer", "error", err)
 		return nil, ErrInternalServerError
+	}
+
+	if err := permissions.CheckAccess(ctx, lb.OwnerID, actionLoadBalancerGet); err != nil {
+		return nil, err
 	}
 
 	return lb, nil

--- a/internal/graphapi/origin.resolvers.go
+++ b/internal/graphapi/origin.resolvers.go
@@ -74,7 +74,7 @@ func (r *mutationResolver) LoadBalancerOriginUpdate(ctx context.Context, id gidx
 		return nil, err
 	}
 
-	ogn, err := r.client.Origin.Get(ctx, id)
+	ogn, err := r.client.Origin.Query().WithPool().Where(origin.IDEQ(id)).Only(ctx)
 	if err != nil {
 		if generated.IsNotFound(err) {
 			return nil, err
@@ -84,7 +84,7 @@ func (r *mutationResolver) LoadBalancerOriginUpdate(ctx context.Context, id gidx
 		return nil, ErrInternalServerError
 	}
 
-	if err := permissions.CheckAccess(ctx, ogn.PoolID, actionLoadBalancerPoolUpdate); err != nil {
+	if err := permissions.CheckAccess(ctx, ogn.Edges.Pool.OwnerID, actionLoadBalancerPoolUpdate); err != nil {
 		return nil, err
 	}
 
@@ -121,7 +121,7 @@ func (r *mutationResolver) LoadBalancerOriginDelete(ctx context.Context, id gidx
 		return nil, err
 	}
 
-	ogn, err := r.client.Origin.Get(ctx, id)
+	ogn, err := r.client.Origin.Query().WithPool().Where(origin.IDEQ(id)).Only(ctx)
 	if err != nil {
 		if generated.IsNotFound(err) {
 			return nil, err
@@ -131,7 +131,7 @@ func (r *mutationResolver) LoadBalancerOriginDelete(ctx context.Context, id gidx
 		return nil, ErrInternalServerError
 	}
 
-	if err := permissions.CheckAccess(ctx, ogn.PoolID, actionLoadBalancerPoolUpdate); err != nil {
+	if err := permissions.CheckAccess(ctx, ogn.Edges.Pool.OwnerID, actionLoadBalancerPoolUpdate); err != nil {
 		return nil, err
 	}
 

--- a/internal/graphapi/port.resolvers.go
+++ b/internal/graphapi/port.resolvers.go
@@ -13,6 +13,7 @@ import (
 
 	"go.infratographer.com/load-balancer-api/internal/ent/generated"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/pool"
+	"go.infratographer.com/load-balancer-api/internal/ent/generated/port"
 	"go.infratographer.com/load-balancer-api/pkg/metadata"
 )
 
@@ -93,7 +94,7 @@ func (r *mutationResolver) LoadBalancerPortUpdate(ctx context.Context, id gidx.P
 		return nil, err
 	}
 
-	p, err := r.client.Port.Get(ctx, id)
+	p, err := r.client.Port.Query().WithLoadBalancer().Where(port.IDEQ(id)).Only(ctx)
 	if err != nil {
 		if generated.IsNotFound(err) {
 			return nil, err
@@ -103,7 +104,7 @@ func (r *mutationResolver) LoadBalancerPortUpdate(ctx context.Context, id gidx.P
 		return nil, ErrInternalServerError
 	}
 
-	if err := permissions.CheckAccess(ctx, p.LoadBalancerID, actionLoadBalancerUpdate); err != nil {
+	if err := permissions.CheckAccess(ctx, p.Edges.LoadBalancer.OwnerID, actionLoadBalancerUpdate); err != nil {
 		return nil, err
 	}
 
@@ -164,7 +165,7 @@ func (r *mutationResolver) LoadBalancerPortDelete(ctx context.Context, id gidx.P
 		return nil, err
 	}
 
-	p, err := r.client.Port.Get(ctx, id)
+	p, err := r.client.Port.Query().WithLoadBalancer().Where(port.IDEQ(id)).Only(ctx)
 	if err != nil {
 		if generated.IsNotFound(err) {
 			return nil, err
@@ -174,7 +175,7 @@ func (r *mutationResolver) LoadBalancerPortDelete(ctx context.Context, id gidx.P
 		return nil, ErrInternalServerError
 	}
 
-	if err := permissions.CheckAccess(ctx, p.LoadBalancerID, actionLoadBalancerUpdate); err != nil {
+	if err := permissions.CheckAccess(ctx, p.Edges.LoadBalancer.OwnerID, actionLoadBalancerUpdate); err != nil {
 		return nil, err
 	}
 

--- a/internal/manualhooks/hooks.go
+++ b/internal/manualhooks/hooks.go
@@ -1002,6 +1002,11 @@ func PortHooks() []ent.Hook {
 						})
 					}
 
+					relationships = append(relationships, events.AuthRelationshipRelation{
+						Relation:  "loadbalancer",
+						SubjectID: load_balancer_id,
+					})
+
 					msg := events.ChangeMessage{
 						EventType:            eventType(m.Op()),
 						SubjectID:            objID,
@@ -1089,6 +1094,11 @@ func PortHooks() []ent.Hook {
 					additionalSubjects = append(additionalSubjects, dbObj.Edges.LoadBalancer.OwnerID)
 					additionalSubjects = append(additionalSubjects, dbObj.Edges.LoadBalancer.ProviderID)
 
+					relationships = append(relationships, events.AuthRelationshipRelation{
+						Relation:  "loadbalancer",
+						SubjectID: dbObj.LoadBalancerID,
+					})
+					
 					// we have all the info we need, now complete the mutation before we process the event
 					retValue, err := next.Mutate(ctx, m)
 					if err != nil {


### PR DESCRIPTION
# Summary

Check permissions access to resources in the resolvers against the `ownerID`, rather than the resource `gidx`, where possible. 