### PR TITLE
Add soft deletes to loadbalancer api

### DIFF
--- a/db/migrations/20240207222332_softdelete.sql
+++ b/db/migrations/20240207222332_softdelete.sql
@@ -1,7 +1,0 @@
--- +goose Up
--- modify "load_balancers" table
-ALTER TABLE "load_balancers" ADD COLUMN "deleted_at" timestamptz NULL, ADD COLUMN "deleted_by" character varying NULL;
-
--- +goose Down
--- reverse: modify "load_balancers" table
-ALTER TABLE "load_balancers" DROP COLUMN "deleted_by", DROP COLUMN "deleted_at";

--- a/db/migrations/20240207222332_softdelete.sql
+++ b/db/migrations/20240207222332_softdelete.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+-- modify "load_balancers" table
+ALTER TABLE "load_balancers" ADD COLUMN "deleted_at" timestamptz NULL, ADD COLUMN "deleted_by" character varying NULL;
+
+-- +goose Down
+-- reverse: modify "load_balancers" table
+ALTER TABLE "load_balancers" DROP COLUMN "deleted_by", DROP COLUMN "deleted_at";

--- a/db/migrations/20240208121103_softdelete.sql
+++ b/db/migrations/20240208121103_softdelete.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- modify "load_balancers" table
+ALTER TABLE "load_balancers" ADD COLUMN "deleted_at" timestamptz NULL, ADD COLUMN "deleted_by" character varying NULL;
+-- modify "origins" table
+ALTER TABLE "origins" ADD COLUMN "deleted_at" timestamptz NULL, ADD COLUMN "deleted_by" character varying NULL;
+-- modify "pools" table
+ALTER TABLE "pools" ADD COLUMN "deleted_at" timestamptz NULL, ADD COLUMN "deleted_by" character varying NULL;
+-- modify "ports" table
+ALTER TABLE "ports" ADD COLUMN "deleted_at" timestamptz NULL, ADD COLUMN "deleted_by" character varying NULL;
+-- modify "providers" table
+ALTER TABLE "providers" ADD COLUMN "deleted_at" timestamptz NULL, ADD COLUMN "deleted_by" character varying NULL;
+
+-- +goose Down
+-- reverse: modify "providers" table
+ALTER TABLE "providers" DROP COLUMN "deleted_by", DROP COLUMN "deleted_at";
+-- reverse: modify "ports" table
+ALTER TABLE "ports" DROP COLUMN "deleted_by", DROP COLUMN "deleted_at";
+-- reverse: modify "pools" table
+ALTER TABLE "pools" DROP COLUMN "deleted_by", DROP COLUMN "deleted_at";
+-- reverse: modify "origins" table
+ALTER TABLE "origins" DROP COLUMN "deleted_by", DROP COLUMN "deleted_at";
+-- reverse: modify "load_balancers" table
+ALTER TABLE "load_balancers" DROP COLUMN "deleted_by", DROP COLUMN "deleted_at";

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,7 +1,7 @@
-h1:B5D1P3uzbaqfW2iV++ujfqAO9YVdj7IOXFtH0Ll0jJ4=
+h1:0KtiTooJCnoUsSF1CYnlRKEVEQFmH2Fj55S/41WmJr8=
 20230503185445_initial-migration.sql h1:4pqNp2MDBBRdGxU/H5mmZui9oi1SyjIiMVGatajrBeY=
 20230615194819_drop_tenant_add_owner.sql h1:KGCsItU0NYhxYEkhZOaMQjfIrBMnek5rxC6D/LhnyCk=
 20230629085916_drop_status_and_annotations.sql h1:kvDMoaMEjyoj/aRi6rw4XvCLxGH09vGGLbL0/p5tpPo=
 20231017005257_add_origin_weight.sql h1:NuorUbcydDqcyPK8wgwlkQxaH+zGWfVtJW9UPL1Vn+E=
 20240207205734_audit-fields.sql h1:cplFCBB7laCP5Y+UAoxIfITMo56Hoc5XIVvgcfGL9o0=
-20240207222332_softdelete.sql h1:Wu0z4ZDIlcf6hZmapOIpxVsLUXZlR4qJalryKZihwC0=
+20240208121103_softdelete.sql h1:rt3nHn/1KzxSAbJZ33fQJZi5emLk7Q2PCRcfxWUeveY=

--- a/db/migrations/atlas.sum
+++ b/db/migrations/atlas.sum
@@ -1,6 +1,7 @@
-h1:VbjEjTYQpHluH7ZPRqCN9Xz2sRkWFqFjgcQjf19L/xo=
+h1:B5D1P3uzbaqfW2iV++ujfqAO9YVdj7IOXFtH0Ll0jJ4=
 20230503185445_initial-migration.sql h1:4pqNp2MDBBRdGxU/H5mmZui9oi1SyjIiMVGatajrBeY=
 20230615194819_drop_tenant_add_owner.sql h1:KGCsItU0NYhxYEkhZOaMQjfIrBMnek5rxC6D/LhnyCk=
 20230629085916_drop_status_and_annotations.sql h1:kvDMoaMEjyoj/aRi6rw4XvCLxGH09vGGLbL0/p5tpPo=
 20231017005257_add_origin_weight.sql h1:NuorUbcydDqcyPK8wgwlkQxaH+zGWfVtJW9UPL1Vn+E=
 20240207205734_audit-fields.sql h1:cplFCBB7laCP5Y+UAoxIfITMo56Hoc5XIVvgcfGL9o0=
+20240207222332_softdelete.sql h1:Wu0z4ZDIlcf6hZmapOIpxVsLUXZlR4qJalryKZihwC0=

--- a/internal/ent/generated/client.go
+++ b/internal/ent/generated/client.go
@@ -404,7 +404,8 @@ func (c *LoadBalancerClient) Hooks() []Hook {
 
 // Interceptors returns the client interceptors.
 func (c *LoadBalancerClient) Interceptors() []Interceptor {
-	return c.inters.LoadBalancer
+	inters := c.inters.LoadBalancer
+	return append(inters[:len(inters):len(inters)], loadbalancer.Interceptors[:]...)
 }
 
 func (c *LoadBalancerClient) mutate(ctx context.Context, m *LoadBalancerMutation) (Value, error) {

--- a/internal/ent/generated/client.go
+++ b/internal/ent/generated/client.go
@@ -555,7 +555,8 @@ func (c *OriginClient) Hooks() []Hook {
 
 // Interceptors returns the client interceptors.
 func (c *OriginClient) Interceptors() []Interceptor {
-	return c.inters.Origin
+	inters := c.inters.Origin
+	return append(inters[:len(inters):len(inters)], origin.Interceptors[:]...)
 }
 
 func (c *OriginClient) mutate(ctx context.Context, m *OriginMutation) (Value, error) {
@@ -721,7 +722,8 @@ func (c *PoolClient) Hooks() []Hook {
 
 // Interceptors returns the client interceptors.
 func (c *PoolClient) Interceptors() []Interceptor {
-	return c.inters.Pool
+	inters := c.inters.Pool
+	return append(inters[:len(inters):len(inters)], pool.Interceptors[:]...)
 }
 
 func (c *PoolClient) mutate(ctx context.Context, m *PoolMutation) (Value, error) {
@@ -887,7 +889,8 @@ func (c *PortClient) Hooks() []Hook {
 
 // Interceptors returns the client interceptors.
 func (c *PortClient) Interceptors() []Interceptor {
-	return c.inters.Port
+	inters := c.inters.Port
+	return append(inters[:len(inters):len(inters)], port.Interceptors[:]...)
 }
 
 func (c *PortClient) mutate(ctx context.Context, m *PortMutation) (Value, error) {
@@ -1037,7 +1040,8 @@ func (c *ProviderClient) Hooks() []Hook {
 
 // Interceptors returns the client interceptors.
 func (c *ProviderClient) Interceptors() []Interceptor {
-	return c.inters.Provider
+	inters := c.inters.Provider
+	return append(inters[:len(inters):len(inters)], provider.Interceptors[:]...)
 }
 
 func (c *ProviderClient) mutate(ctx context.Context, m *ProviderMutation) (Value, error) {

--- a/internal/ent/generated/gql_collection.go
+++ b/internal/ent/generated/gql_collection.go
@@ -171,6 +171,16 @@ func (lb *LoadBalancerQuery) collectField(ctx context.Context, opCtx *graphql.Op
 				selectedFields = append(selectedFields, loadbalancer.FieldUpdatedBy)
 				fieldSeen[loadbalancer.FieldUpdatedBy] = struct{}{}
 			}
+		case "deletedAt":
+			if _, ok := fieldSeen[loadbalancer.FieldDeletedAt]; !ok {
+				selectedFields = append(selectedFields, loadbalancer.FieldDeletedAt)
+				fieldSeen[loadbalancer.FieldDeletedAt] = struct{}{}
+			}
+		case "deletedBy":
+			if _, ok := fieldSeen[loadbalancer.FieldDeletedBy]; !ok {
+				selectedFields = append(selectedFields, loadbalancer.FieldDeletedBy)
+				fieldSeen[loadbalancer.FieldDeletedBy] = struct{}{}
+			}
 		case "name":
 			if _, ok := fieldSeen[loadbalancer.FieldName]; !ok {
 				selectedFields = append(selectedFields, loadbalancer.FieldName)

--- a/internal/ent/generated/gql_collection.go
+++ b/internal/ent/generated/gql_collection.go
@@ -294,6 +294,16 @@ func (o *OriginQuery) collectField(ctx context.Context, opCtx *graphql.Operation
 				selectedFields = append(selectedFields, origin.FieldUpdatedAt)
 				fieldSeen[origin.FieldUpdatedAt] = struct{}{}
 			}
+		case "deletedAt":
+			if _, ok := fieldSeen[origin.FieldDeletedAt]; !ok {
+				selectedFields = append(selectedFields, origin.FieldDeletedAt)
+				fieldSeen[origin.FieldDeletedAt] = struct{}{}
+			}
+		case "deletedBy":
+			if _, ok := fieldSeen[origin.FieldDeletedBy]; !ok {
+				selectedFields = append(selectedFields, origin.FieldDeletedBy)
+				fieldSeen[origin.FieldDeletedBy] = struct{}{}
+			}
 		case "createdBy":
 			if _, ok := fieldSeen[origin.FieldCreatedBy]; !ok {
 				selectedFields = append(selectedFields, origin.FieldCreatedBy)
@@ -534,6 +544,16 @@ func (po *PoolQuery) collectField(ctx context.Context, opCtx *graphql.OperationC
 				selectedFields = append(selectedFields, pool.FieldUpdatedBy)
 				fieldSeen[pool.FieldUpdatedBy] = struct{}{}
 			}
+		case "deletedAt":
+			if _, ok := fieldSeen[pool.FieldDeletedAt]; !ok {
+				selectedFields = append(selectedFields, pool.FieldDeletedAt)
+				fieldSeen[pool.FieldDeletedAt] = struct{}{}
+			}
+		case "deletedBy":
+			if _, ok := fieldSeen[pool.FieldDeletedBy]; !ok {
+				selectedFields = append(selectedFields, pool.FieldDeletedBy)
+				fieldSeen[pool.FieldDeletedBy] = struct{}{}
+			}
 		case "name":
 			if _, ok := fieldSeen[pool.FieldName]; !ok {
 				selectedFields = append(selectedFields, pool.FieldName)
@@ -668,6 +688,16 @@ func (po *PortQuery) collectField(ctx context.Context, opCtx *graphql.OperationC
 			if _, ok := fieldSeen[port.FieldUpdatedAt]; !ok {
 				selectedFields = append(selectedFields, port.FieldUpdatedAt)
 				fieldSeen[port.FieldUpdatedAt] = struct{}{}
+			}
+		case "deletedAt":
+			if _, ok := fieldSeen[port.FieldDeletedAt]; !ok {
+				selectedFields = append(selectedFields, port.FieldDeletedAt)
+				fieldSeen[port.FieldDeletedAt] = struct{}{}
+			}
+		case "deletedBy":
+			if _, ok := fieldSeen[port.FieldDeletedBy]; !ok {
+				selectedFields = append(selectedFields, port.FieldDeletedBy)
+				fieldSeen[port.FieldDeletedBy] = struct{}{}
 			}
 		case "createdBy":
 			if _, ok := fieldSeen[port.FieldCreatedBy]; !ok {
@@ -871,6 +901,16 @@ func (pr *ProviderQuery) collectField(ctx context.Context, opCtx *graphql.Operat
 			if _, ok := fieldSeen[provider.FieldUpdatedAt]; !ok {
 				selectedFields = append(selectedFields, provider.FieldUpdatedAt)
 				fieldSeen[provider.FieldUpdatedAt] = struct{}{}
+			}
+		case "deletedAt":
+			if _, ok := fieldSeen[provider.FieldDeletedAt]; !ok {
+				selectedFields = append(selectedFields, provider.FieldDeletedAt)
+				fieldSeen[provider.FieldDeletedAt] = struct{}{}
+			}
+		case "deletedBy":
+			if _, ok := fieldSeen[provider.FieldDeletedBy]; !ok {
+				selectedFields = append(selectedFields, provider.FieldDeletedBy)
+				fieldSeen[provider.FieldDeletedBy] = struct{}{}
 			}
 		case "createdBy":
 			if _, ok := fieldSeen[provider.FieldCreatedBy]; !ok {

--- a/internal/ent/generated/gql_pagination.go
+++ b/internal/ent/generated/gql_pagination.go
@@ -791,6 +791,34 @@ var (
 			}
 		},
 	}
+	// OriginOrderFieldDeletedAt orders Origin by deleted_at.
+	OriginOrderFieldDeletedAt = &LoadBalancerOriginOrderField{
+		Value: func(o *LoadBalancerOrigin) (ent.Value, error) {
+			return o.DeletedAt, nil
+		},
+		column: origin.FieldDeletedAt,
+		toTerm: origin.ByDeletedAt,
+		toCursor: func(o *LoadBalancerOrigin) Cursor {
+			return Cursor{
+				ID:    o.ID,
+				Value: o.DeletedAt,
+			}
+		},
+	}
+	// OriginOrderFieldDeletedBy orders Origin by deleted_by.
+	OriginOrderFieldDeletedBy = &LoadBalancerOriginOrderField{
+		Value: func(o *LoadBalancerOrigin) (ent.Value, error) {
+			return o.DeletedBy, nil
+		},
+		column: origin.FieldDeletedBy,
+		toTerm: origin.ByDeletedBy,
+		toCursor: func(o *LoadBalancerOrigin) Cursor {
+			return Cursor{
+				ID:    o.ID,
+				Value: o.DeletedBy,
+			}
+		},
+	}
 	// OriginOrderFieldCreatedBy orders Origin by created_by.
 	OriginOrderFieldCreatedBy = &LoadBalancerOriginOrderField{
 		Value: func(o *LoadBalancerOrigin) (ent.Value, error) {
@@ -899,6 +927,10 @@ func (f LoadBalancerOriginOrderField) String() string {
 		str = "CREATED_AT"
 	case OriginOrderFieldUpdatedAt.column:
 		str = "UPDATED_AT"
+	case OriginOrderFieldDeletedAt.column:
+		str = "DELETED_AT"
+	case OriginOrderFieldDeletedBy.column:
+		str = "DELETED_BY"
 	case OriginOrderFieldCreatedBy.column:
 		str = "CREATED_BY"
 	case OriginOrderFieldUpdatedBy.column:
@@ -933,6 +965,10 @@ func (f *LoadBalancerOriginOrderField) UnmarshalGQL(v interface{}) error {
 		*f = *OriginOrderFieldCreatedAt
 	case "UPDATED_AT":
 		*f = *OriginOrderFieldUpdatedAt
+	case "DELETED_AT":
+		*f = *OriginOrderFieldDeletedAt
+	case "DELETED_BY":
+		*f = *OriginOrderFieldDeletedBy
 	case "CREATED_BY":
 		*f = *OriginOrderFieldCreatedBy
 	case "UPDATED_BY":
@@ -1259,6 +1295,34 @@ var (
 			}
 		},
 	}
+	// PoolOrderFieldDeletedAt orders Pool by deleted_at.
+	PoolOrderFieldDeletedAt = &LoadBalancerPoolOrderField{
+		Value: func(po *LoadBalancerPool) (ent.Value, error) {
+			return po.DeletedAt, nil
+		},
+		column: pool.FieldDeletedAt,
+		toTerm: pool.ByDeletedAt,
+		toCursor: func(po *LoadBalancerPool) Cursor {
+			return Cursor{
+				ID:    po.ID,
+				Value: po.DeletedAt,
+			}
+		},
+	}
+	// PoolOrderFieldDeletedBy orders Pool by deleted_by.
+	PoolOrderFieldDeletedBy = &LoadBalancerPoolOrderField{
+		Value: func(po *LoadBalancerPool) (ent.Value, error) {
+			return po.DeletedBy, nil
+		},
+		column: pool.FieldDeletedBy,
+		toTerm: pool.ByDeletedBy,
+		toCursor: func(po *LoadBalancerPool) Cursor {
+			return Cursor{
+				ID:    po.ID,
+				Value: po.DeletedBy,
+			}
+		},
+	}
 	// PoolOrderFieldName orders Pool by name.
 	PoolOrderFieldName = &LoadBalancerPoolOrderField{
 		Value: func(po *LoadBalancerPool) (ent.Value, error) {
@@ -1301,6 +1365,10 @@ func (f LoadBalancerPoolOrderField) String() string {
 		str = "CREATED_BY"
 	case PoolOrderFieldUpdatedBy.column:
 		str = "UPDATED_BY"
+	case PoolOrderFieldDeletedAt.column:
+		str = "DELETED_AT"
+	case PoolOrderFieldDeletedBy.column:
+		str = "DELETED_BY"
 	case PoolOrderFieldName.column:
 		str = "name"
 	case PoolOrderFieldProtocol.column:
@@ -1329,6 +1397,10 @@ func (f *LoadBalancerPoolOrderField) UnmarshalGQL(v interface{}) error {
 		*f = *PoolOrderFieldCreatedBy
 	case "UPDATED_BY":
 		*f = *PoolOrderFieldUpdatedBy
+	case "DELETED_AT":
+		*f = *PoolOrderFieldDeletedAt
+	case "DELETED_BY":
+		*f = *PoolOrderFieldDeletedBy
 	case "name":
 		*f = *PoolOrderFieldName
 	case "protocol":
@@ -1617,6 +1689,34 @@ var (
 			}
 		},
 	}
+	// PortOrderFieldDeletedAt orders Port by deleted_at.
+	PortOrderFieldDeletedAt = &LoadBalancerPortOrderField{
+		Value: func(po *LoadBalancerPort) (ent.Value, error) {
+			return po.DeletedAt, nil
+		},
+		column: port.FieldDeletedAt,
+		toTerm: port.ByDeletedAt,
+		toCursor: func(po *LoadBalancerPort) Cursor {
+			return Cursor{
+				ID:    po.ID,
+				Value: po.DeletedAt,
+			}
+		},
+	}
+	// PortOrderFieldDeletedBy orders Port by deleted_by.
+	PortOrderFieldDeletedBy = &LoadBalancerPortOrderField{
+		Value: func(po *LoadBalancerPort) (ent.Value, error) {
+			return po.DeletedBy, nil
+		},
+		column: port.FieldDeletedBy,
+		toTerm: port.ByDeletedBy,
+		toCursor: func(po *LoadBalancerPort) Cursor {
+			return Cursor{
+				ID:    po.ID,
+				Value: po.DeletedBy,
+			}
+		},
+	}
 	// PortOrderFieldCreatedBy orders Port by created_by.
 	PortOrderFieldCreatedBy = &LoadBalancerPortOrderField{
 		Value: func(po *LoadBalancerPort) (ent.Value, error) {
@@ -1683,6 +1783,10 @@ func (f LoadBalancerPortOrderField) String() string {
 		str = "CREATED_AT"
 	case PortOrderFieldUpdatedAt.column:
 		str = "UPDATED_AT"
+	case PortOrderFieldDeletedAt.column:
+		str = "DELETED_AT"
+	case PortOrderFieldDeletedBy.column:
+		str = "DELETED_BY"
 	case PortOrderFieldCreatedBy.column:
 		str = "CREATED_BY"
 	case PortOrderFieldUpdatedBy.column:
@@ -1711,6 +1815,10 @@ func (f *LoadBalancerPortOrderField) UnmarshalGQL(v interface{}) error {
 		*f = *PortOrderFieldCreatedAt
 	case "UPDATED_AT":
 		*f = *PortOrderFieldUpdatedAt
+	case "DELETED_AT":
+		*f = *PortOrderFieldDeletedAt
+	case "DELETED_BY":
+		*f = *PortOrderFieldDeletedBy
 	case "CREATED_BY":
 		*f = *PortOrderFieldCreatedBy
 	case "UPDATED_BY":
@@ -2017,6 +2125,34 @@ var (
 			}
 		},
 	}
+	// ProviderOrderFieldDeletedAt orders Provider by deleted_at.
+	ProviderOrderFieldDeletedAt = &LoadBalancerProviderOrderField{
+		Value: func(pr *LoadBalancerProvider) (ent.Value, error) {
+			return pr.DeletedAt, nil
+		},
+		column: provider.FieldDeletedAt,
+		toTerm: provider.ByDeletedAt,
+		toCursor: func(pr *LoadBalancerProvider) Cursor {
+			return Cursor{
+				ID:    pr.ID,
+				Value: pr.DeletedAt,
+			}
+		},
+	}
+	// ProviderOrderFieldDeletedBy orders Provider by deleted_by.
+	ProviderOrderFieldDeletedBy = &LoadBalancerProviderOrderField{
+		Value: func(pr *LoadBalancerProvider) (ent.Value, error) {
+			return pr.DeletedBy, nil
+		},
+		column: provider.FieldDeletedBy,
+		toTerm: provider.ByDeletedBy,
+		toCursor: func(pr *LoadBalancerProvider) Cursor {
+			return Cursor{
+				ID:    pr.ID,
+				Value: pr.DeletedBy,
+			}
+		},
+	}
 	// ProviderOrderFieldCreatedBy orders Provider by created_by.
 	ProviderOrderFieldCreatedBy = &LoadBalancerProviderOrderField{
 		Value: func(pr *LoadBalancerProvider) (ent.Value, error) {
@@ -2085,6 +2221,10 @@ func (f LoadBalancerProviderOrderField) String() string {
 		str = "CREATED_AT"
 	case ProviderOrderFieldUpdatedAt.column:
 		str = "UPDATED_AT"
+	case ProviderOrderFieldDeletedAt.column:
+		str = "DELETED_AT"
+	case ProviderOrderFieldDeletedBy.column:
+		str = "DELETED_BY"
 	case ProviderOrderFieldCreatedBy.column:
 		str = "CREATED_BY"
 	case ProviderOrderFieldUpdatedBy.column:
@@ -2115,6 +2255,10 @@ func (f *LoadBalancerProviderOrderField) UnmarshalGQL(v interface{}) error {
 		*f = *ProviderOrderFieldCreatedAt
 	case "UPDATED_AT":
 		*f = *ProviderOrderFieldUpdatedAt
+	case "DELETED_AT":
+		*f = *ProviderOrderFieldDeletedAt
+	case "DELETED_BY":
+		*f = *ProviderOrderFieldDeletedBy
 	case "CREATED_BY":
 		*f = *ProviderOrderFieldCreatedBy
 	case "UPDATED_BY":

--- a/internal/ent/generated/gql_pagination.go
+++ b/internal/ent/generated/gql_pagination.go
@@ -393,6 +393,34 @@ var (
 			}
 		},
 	}
+	// LoadBalancerOrderFieldDeletedAt orders LoadBalancer by deleted_at.
+	LoadBalancerOrderFieldDeletedAt = &LoadBalancerOrderField{
+		Value: func(lb *LoadBalancer) (ent.Value, error) {
+			return lb.DeletedAt, nil
+		},
+		column: loadbalancer.FieldDeletedAt,
+		toTerm: loadbalancer.ByDeletedAt,
+		toCursor: func(lb *LoadBalancer) Cursor {
+			return Cursor{
+				ID:    lb.ID,
+				Value: lb.DeletedAt,
+			}
+		},
+	}
+	// LoadBalancerOrderFieldDeletedBy orders LoadBalancer by deleted_by.
+	LoadBalancerOrderFieldDeletedBy = &LoadBalancerOrderField{
+		Value: func(lb *LoadBalancer) (ent.Value, error) {
+			return lb.DeletedBy, nil
+		},
+		column: loadbalancer.FieldDeletedBy,
+		toTerm: loadbalancer.ByDeletedBy,
+		toCursor: func(lb *LoadBalancer) Cursor {
+			return Cursor{
+				ID:    lb.ID,
+				Value: lb.DeletedBy,
+			}
+		},
+	}
 	// LoadBalancerOrderFieldName orders LoadBalancer by name.
 	LoadBalancerOrderFieldName = &LoadBalancerOrderField{
 		Value: func(lb *LoadBalancer) (ent.Value, error) {
@@ -437,6 +465,10 @@ func (f LoadBalancerOrderField) String() string {
 		str = "CREATED_BY"
 	case LoadBalancerOrderFieldUpdatedBy.column:
 		str = "UPDATED_BY"
+	case LoadBalancerOrderFieldDeletedAt.column:
+		str = "DELETED_AT"
+	case LoadBalancerOrderFieldDeletedBy.column:
+		str = "DELETED_BY"
 	case LoadBalancerOrderFieldName.column:
 		str = "NAME"
 	case LoadBalancerOrderFieldOwnerID.column:
@@ -467,6 +499,10 @@ func (f *LoadBalancerOrderField) UnmarshalGQL(v interface{}) error {
 		*f = *LoadBalancerOrderFieldCreatedBy
 	case "UPDATED_BY":
 		*f = *LoadBalancerOrderFieldUpdatedBy
+	case "DELETED_AT":
+		*f = *LoadBalancerOrderFieldDeletedAt
+	case "DELETED_BY":
+		*f = *LoadBalancerOrderFieldDeletedBy
 	case "NAME":
 		*f = *LoadBalancerOrderFieldName
 	case "OWNER":

--- a/internal/ent/generated/gql_where_input.go
+++ b/internal/ent/generated/gql_where_input.go
@@ -101,6 +101,35 @@ type LoadBalancerWhereInput struct {
 	UpdatedByEqualFold    *string  `json:"updatedByEqualFold,omitempty"`
 	UpdatedByContainsFold *string  `json:"updatedByContainsFold,omitempty"`
 
+	// "deleted_at" field predicates.
+	DeletedAt       *time.Time  `json:"deletedAt,omitempty"`
+	DeletedAtNEQ    *time.Time  `json:"deletedAtNEQ,omitempty"`
+	DeletedAtIn     []time.Time `json:"deletedAtIn,omitempty"`
+	DeletedAtNotIn  []time.Time `json:"deletedAtNotIn,omitempty"`
+	DeletedAtGT     *time.Time  `json:"deletedAtGT,omitempty"`
+	DeletedAtGTE    *time.Time  `json:"deletedAtGTE,omitempty"`
+	DeletedAtLT     *time.Time  `json:"deletedAtLT,omitempty"`
+	DeletedAtLTE    *time.Time  `json:"deletedAtLTE,omitempty"`
+	DeletedAtIsNil  bool        `json:"deletedAtIsNil,omitempty"`
+	DeletedAtNotNil bool        `json:"deletedAtNotNil,omitempty"`
+
+	// "deleted_by" field predicates.
+	DeletedBy             *string  `json:"deletedBy,omitempty"`
+	DeletedByNEQ          *string  `json:"deletedByNEQ,omitempty"`
+	DeletedByIn           []string `json:"deletedByIn,omitempty"`
+	DeletedByNotIn        []string `json:"deletedByNotIn,omitempty"`
+	DeletedByGT           *string  `json:"deletedByGT,omitempty"`
+	DeletedByGTE          *string  `json:"deletedByGTE,omitempty"`
+	DeletedByLT           *string  `json:"deletedByLT,omitempty"`
+	DeletedByLTE          *string  `json:"deletedByLTE,omitempty"`
+	DeletedByContains     *string  `json:"deletedByContains,omitempty"`
+	DeletedByHasPrefix    *string  `json:"deletedByHasPrefix,omitempty"`
+	DeletedByHasSuffix    *string  `json:"deletedByHasSuffix,omitempty"`
+	DeletedByIsNil        bool     `json:"deletedByIsNil,omitempty"`
+	DeletedByNotNil       bool     `json:"deletedByNotNil,omitempty"`
+	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
+	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
+
 	// "name" field predicates.
 	Name             *string  `json:"name,omitempty"`
 	NameNEQ          *string  `json:"nameNEQ,omitempty"`
@@ -357,6 +386,81 @@ func (i *LoadBalancerWhereInput) P() (predicate.LoadBalancer, error) {
 	}
 	if i.UpdatedByContainsFold != nil {
 		predicates = append(predicates, loadbalancer.UpdatedByContainsFold(*i.UpdatedByContainsFold))
+	}
+	if i.DeletedAt != nil {
+		predicates = append(predicates, loadbalancer.DeletedAtEQ(*i.DeletedAt))
+	}
+	if i.DeletedAtNEQ != nil {
+		predicates = append(predicates, loadbalancer.DeletedAtNEQ(*i.DeletedAtNEQ))
+	}
+	if len(i.DeletedAtIn) > 0 {
+		predicates = append(predicates, loadbalancer.DeletedAtIn(i.DeletedAtIn...))
+	}
+	if len(i.DeletedAtNotIn) > 0 {
+		predicates = append(predicates, loadbalancer.DeletedAtNotIn(i.DeletedAtNotIn...))
+	}
+	if i.DeletedAtGT != nil {
+		predicates = append(predicates, loadbalancer.DeletedAtGT(*i.DeletedAtGT))
+	}
+	if i.DeletedAtGTE != nil {
+		predicates = append(predicates, loadbalancer.DeletedAtGTE(*i.DeletedAtGTE))
+	}
+	if i.DeletedAtLT != nil {
+		predicates = append(predicates, loadbalancer.DeletedAtLT(*i.DeletedAtLT))
+	}
+	if i.DeletedAtLTE != nil {
+		predicates = append(predicates, loadbalancer.DeletedAtLTE(*i.DeletedAtLTE))
+	}
+	if i.DeletedAtIsNil {
+		predicates = append(predicates, loadbalancer.DeletedAtIsNil())
+	}
+	if i.DeletedAtNotNil {
+		predicates = append(predicates, loadbalancer.DeletedAtNotNil())
+	}
+	if i.DeletedBy != nil {
+		predicates = append(predicates, loadbalancer.DeletedByEQ(*i.DeletedBy))
+	}
+	if i.DeletedByNEQ != nil {
+		predicates = append(predicates, loadbalancer.DeletedByNEQ(*i.DeletedByNEQ))
+	}
+	if len(i.DeletedByIn) > 0 {
+		predicates = append(predicates, loadbalancer.DeletedByIn(i.DeletedByIn...))
+	}
+	if len(i.DeletedByNotIn) > 0 {
+		predicates = append(predicates, loadbalancer.DeletedByNotIn(i.DeletedByNotIn...))
+	}
+	if i.DeletedByGT != nil {
+		predicates = append(predicates, loadbalancer.DeletedByGT(*i.DeletedByGT))
+	}
+	if i.DeletedByGTE != nil {
+		predicates = append(predicates, loadbalancer.DeletedByGTE(*i.DeletedByGTE))
+	}
+	if i.DeletedByLT != nil {
+		predicates = append(predicates, loadbalancer.DeletedByLT(*i.DeletedByLT))
+	}
+	if i.DeletedByLTE != nil {
+		predicates = append(predicates, loadbalancer.DeletedByLTE(*i.DeletedByLTE))
+	}
+	if i.DeletedByContains != nil {
+		predicates = append(predicates, loadbalancer.DeletedByContains(*i.DeletedByContains))
+	}
+	if i.DeletedByHasPrefix != nil {
+		predicates = append(predicates, loadbalancer.DeletedByHasPrefix(*i.DeletedByHasPrefix))
+	}
+	if i.DeletedByHasSuffix != nil {
+		predicates = append(predicates, loadbalancer.DeletedByHasSuffix(*i.DeletedByHasSuffix))
+	}
+	if i.DeletedByIsNil {
+		predicates = append(predicates, loadbalancer.DeletedByIsNil())
+	}
+	if i.DeletedByNotNil {
+		predicates = append(predicates, loadbalancer.DeletedByNotNil())
+	}
+	if i.DeletedByEqualFold != nil {
+		predicates = append(predicates, loadbalancer.DeletedByEqualFold(*i.DeletedByEqualFold))
+	}
+	if i.DeletedByContainsFold != nil {
+		predicates = append(predicates, loadbalancer.DeletedByContainsFold(*i.DeletedByContainsFold))
 	}
 	if i.Name != nil {
 		predicates = append(predicates, loadbalancer.NameEQ(*i.Name))

--- a/internal/ent/generated/gql_where_input.go
+++ b/internal/ent/generated/gql_where_input.go
@@ -585,6 +585,35 @@ type LoadBalancerOriginWhereInput struct {
 	UpdatedAtLT    *time.Time  `json:"updatedAtLT,omitempty"`
 	UpdatedAtLTE   *time.Time  `json:"updatedAtLTE,omitempty"`
 
+	// "deleted_at" field predicates.
+	DeletedAt       *time.Time  `json:"deletedAt,omitempty"`
+	DeletedAtNEQ    *time.Time  `json:"deletedAtNEQ,omitempty"`
+	DeletedAtIn     []time.Time `json:"deletedAtIn,omitempty"`
+	DeletedAtNotIn  []time.Time `json:"deletedAtNotIn,omitempty"`
+	DeletedAtGT     *time.Time  `json:"deletedAtGT,omitempty"`
+	DeletedAtGTE    *time.Time  `json:"deletedAtGTE,omitempty"`
+	DeletedAtLT     *time.Time  `json:"deletedAtLT,omitempty"`
+	DeletedAtLTE    *time.Time  `json:"deletedAtLTE,omitempty"`
+	DeletedAtIsNil  bool        `json:"deletedAtIsNil,omitempty"`
+	DeletedAtNotNil bool        `json:"deletedAtNotNil,omitempty"`
+
+	// "deleted_by" field predicates.
+	DeletedBy             *string  `json:"deletedBy,omitempty"`
+	DeletedByNEQ          *string  `json:"deletedByNEQ,omitempty"`
+	DeletedByIn           []string `json:"deletedByIn,omitempty"`
+	DeletedByNotIn        []string `json:"deletedByNotIn,omitempty"`
+	DeletedByGT           *string  `json:"deletedByGT,omitempty"`
+	DeletedByGTE          *string  `json:"deletedByGTE,omitempty"`
+	DeletedByLT           *string  `json:"deletedByLT,omitempty"`
+	DeletedByLTE          *string  `json:"deletedByLTE,omitempty"`
+	DeletedByContains     *string  `json:"deletedByContains,omitempty"`
+	DeletedByHasPrefix    *string  `json:"deletedByHasPrefix,omitempty"`
+	DeletedByHasSuffix    *string  `json:"deletedByHasSuffix,omitempty"`
+	DeletedByIsNil        bool     `json:"deletedByIsNil,omitempty"`
+	DeletedByNotNil       bool     `json:"deletedByNotNil,omitempty"`
+	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
+	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
+
 	// "created_by" field predicates.
 	CreatedBy             *string  `json:"createdBy,omitempty"`
 	CreatedByNEQ          *string  `json:"createdByNEQ,omitempty"`
@@ -820,6 +849,81 @@ func (i *LoadBalancerOriginWhereInput) P() (predicate.Origin, error) {
 	}
 	if i.UpdatedAtLTE != nil {
 		predicates = append(predicates, origin.UpdatedAtLTE(*i.UpdatedAtLTE))
+	}
+	if i.DeletedAt != nil {
+		predicates = append(predicates, origin.DeletedAtEQ(*i.DeletedAt))
+	}
+	if i.DeletedAtNEQ != nil {
+		predicates = append(predicates, origin.DeletedAtNEQ(*i.DeletedAtNEQ))
+	}
+	if len(i.DeletedAtIn) > 0 {
+		predicates = append(predicates, origin.DeletedAtIn(i.DeletedAtIn...))
+	}
+	if len(i.DeletedAtNotIn) > 0 {
+		predicates = append(predicates, origin.DeletedAtNotIn(i.DeletedAtNotIn...))
+	}
+	if i.DeletedAtGT != nil {
+		predicates = append(predicates, origin.DeletedAtGT(*i.DeletedAtGT))
+	}
+	if i.DeletedAtGTE != nil {
+		predicates = append(predicates, origin.DeletedAtGTE(*i.DeletedAtGTE))
+	}
+	if i.DeletedAtLT != nil {
+		predicates = append(predicates, origin.DeletedAtLT(*i.DeletedAtLT))
+	}
+	if i.DeletedAtLTE != nil {
+		predicates = append(predicates, origin.DeletedAtLTE(*i.DeletedAtLTE))
+	}
+	if i.DeletedAtIsNil {
+		predicates = append(predicates, origin.DeletedAtIsNil())
+	}
+	if i.DeletedAtNotNil {
+		predicates = append(predicates, origin.DeletedAtNotNil())
+	}
+	if i.DeletedBy != nil {
+		predicates = append(predicates, origin.DeletedByEQ(*i.DeletedBy))
+	}
+	if i.DeletedByNEQ != nil {
+		predicates = append(predicates, origin.DeletedByNEQ(*i.DeletedByNEQ))
+	}
+	if len(i.DeletedByIn) > 0 {
+		predicates = append(predicates, origin.DeletedByIn(i.DeletedByIn...))
+	}
+	if len(i.DeletedByNotIn) > 0 {
+		predicates = append(predicates, origin.DeletedByNotIn(i.DeletedByNotIn...))
+	}
+	if i.DeletedByGT != nil {
+		predicates = append(predicates, origin.DeletedByGT(*i.DeletedByGT))
+	}
+	if i.DeletedByGTE != nil {
+		predicates = append(predicates, origin.DeletedByGTE(*i.DeletedByGTE))
+	}
+	if i.DeletedByLT != nil {
+		predicates = append(predicates, origin.DeletedByLT(*i.DeletedByLT))
+	}
+	if i.DeletedByLTE != nil {
+		predicates = append(predicates, origin.DeletedByLTE(*i.DeletedByLTE))
+	}
+	if i.DeletedByContains != nil {
+		predicates = append(predicates, origin.DeletedByContains(*i.DeletedByContains))
+	}
+	if i.DeletedByHasPrefix != nil {
+		predicates = append(predicates, origin.DeletedByHasPrefix(*i.DeletedByHasPrefix))
+	}
+	if i.DeletedByHasSuffix != nil {
+		predicates = append(predicates, origin.DeletedByHasSuffix(*i.DeletedByHasSuffix))
+	}
+	if i.DeletedByIsNil {
+		predicates = append(predicates, origin.DeletedByIsNil())
+	}
+	if i.DeletedByNotNil {
+		predicates = append(predicates, origin.DeletedByNotNil())
+	}
+	if i.DeletedByEqualFold != nil {
+		predicates = append(predicates, origin.DeletedByEqualFold(*i.DeletedByEqualFold))
+	}
+	if i.DeletedByContainsFold != nil {
+		predicates = append(predicates, origin.DeletedByContainsFold(*i.DeletedByContainsFold))
 	}
 	if i.CreatedBy != nil {
 		predicates = append(predicates, origin.CreatedByEQ(*i.CreatedBy))
@@ -1143,6 +1247,35 @@ type LoadBalancerPoolWhereInput struct {
 	UpdatedByEqualFold    *string  `json:"updatedByEqualFold,omitempty"`
 	UpdatedByContainsFold *string  `json:"updatedByContainsFold,omitempty"`
 
+	// "deleted_at" field predicates.
+	DeletedAt       *time.Time  `json:"deletedAt,omitempty"`
+	DeletedAtNEQ    *time.Time  `json:"deletedAtNEQ,omitempty"`
+	DeletedAtIn     []time.Time `json:"deletedAtIn,omitempty"`
+	DeletedAtNotIn  []time.Time `json:"deletedAtNotIn,omitempty"`
+	DeletedAtGT     *time.Time  `json:"deletedAtGT,omitempty"`
+	DeletedAtGTE    *time.Time  `json:"deletedAtGTE,omitempty"`
+	DeletedAtLT     *time.Time  `json:"deletedAtLT,omitempty"`
+	DeletedAtLTE    *time.Time  `json:"deletedAtLTE,omitempty"`
+	DeletedAtIsNil  bool        `json:"deletedAtIsNil,omitempty"`
+	DeletedAtNotNil bool        `json:"deletedAtNotNil,omitempty"`
+
+	// "deleted_by" field predicates.
+	DeletedBy             *string  `json:"deletedBy,omitempty"`
+	DeletedByNEQ          *string  `json:"deletedByNEQ,omitempty"`
+	DeletedByIn           []string `json:"deletedByIn,omitempty"`
+	DeletedByNotIn        []string `json:"deletedByNotIn,omitempty"`
+	DeletedByGT           *string  `json:"deletedByGT,omitempty"`
+	DeletedByGTE          *string  `json:"deletedByGTE,omitempty"`
+	DeletedByLT           *string  `json:"deletedByLT,omitempty"`
+	DeletedByLTE          *string  `json:"deletedByLTE,omitempty"`
+	DeletedByContains     *string  `json:"deletedByContains,omitempty"`
+	DeletedByHasPrefix    *string  `json:"deletedByHasPrefix,omitempty"`
+	DeletedByHasSuffix    *string  `json:"deletedByHasSuffix,omitempty"`
+	DeletedByIsNil        bool     `json:"deletedByIsNil,omitempty"`
+	DeletedByNotNil       bool     `json:"deletedByNotNil,omitempty"`
+	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
+	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
+
 	// "name" field predicates.
 	Name             *string  `json:"name,omitempty"`
 	NameNEQ          *string  `json:"nameNEQ,omitempty"`
@@ -1406,6 +1539,81 @@ func (i *LoadBalancerPoolWhereInput) P() (predicate.Pool, error) {
 	if i.UpdatedByContainsFold != nil {
 		predicates = append(predicates, pool.UpdatedByContainsFold(*i.UpdatedByContainsFold))
 	}
+	if i.DeletedAt != nil {
+		predicates = append(predicates, pool.DeletedAtEQ(*i.DeletedAt))
+	}
+	if i.DeletedAtNEQ != nil {
+		predicates = append(predicates, pool.DeletedAtNEQ(*i.DeletedAtNEQ))
+	}
+	if len(i.DeletedAtIn) > 0 {
+		predicates = append(predicates, pool.DeletedAtIn(i.DeletedAtIn...))
+	}
+	if len(i.DeletedAtNotIn) > 0 {
+		predicates = append(predicates, pool.DeletedAtNotIn(i.DeletedAtNotIn...))
+	}
+	if i.DeletedAtGT != nil {
+		predicates = append(predicates, pool.DeletedAtGT(*i.DeletedAtGT))
+	}
+	if i.DeletedAtGTE != nil {
+		predicates = append(predicates, pool.DeletedAtGTE(*i.DeletedAtGTE))
+	}
+	if i.DeletedAtLT != nil {
+		predicates = append(predicates, pool.DeletedAtLT(*i.DeletedAtLT))
+	}
+	if i.DeletedAtLTE != nil {
+		predicates = append(predicates, pool.DeletedAtLTE(*i.DeletedAtLTE))
+	}
+	if i.DeletedAtIsNil {
+		predicates = append(predicates, pool.DeletedAtIsNil())
+	}
+	if i.DeletedAtNotNil {
+		predicates = append(predicates, pool.DeletedAtNotNil())
+	}
+	if i.DeletedBy != nil {
+		predicates = append(predicates, pool.DeletedByEQ(*i.DeletedBy))
+	}
+	if i.DeletedByNEQ != nil {
+		predicates = append(predicates, pool.DeletedByNEQ(*i.DeletedByNEQ))
+	}
+	if len(i.DeletedByIn) > 0 {
+		predicates = append(predicates, pool.DeletedByIn(i.DeletedByIn...))
+	}
+	if len(i.DeletedByNotIn) > 0 {
+		predicates = append(predicates, pool.DeletedByNotIn(i.DeletedByNotIn...))
+	}
+	if i.DeletedByGT != nil {
+		predicates = append(predicates, pool.DeletedByGT(*i.DeletedByGT))
+	}
+	if i.DeletedByGTE != nil {
+		predicates = append(predicates, pool.DeletedByGTE(*i.DeletedByGTE))
+	}
+	if i.DeletedByLT != nil {
+		predicates = append(predicates, pool.DeletedByLT(*i.DeletedByLT))
+	}
+	if i.DeletedByLTE != nil {
+		predicates = append(predicates, pool.DeletedByLTE(*i.DeletedByLTE))
+	}
+	if i.DeletedByContains != nil {
+		predicates = append(predicates, pool.DeletedByContains(*i.DeletedByContains))
+	}
+	if i.DeletedByHasPrefix != nil {
+		predicates = append(predicates, pool.DeletedByHasPrefix(*i.DeletedByHasPrefix))
+	}
+	if i.DeletedByHasSuffix != nil {
+		predicates = append(predicates, pool.DeletedByHasSuffix(*i.DeletedByHasSuffix))
+	}
+	if i.DeletedByIsNil {
+		predicates = append(predicates, pool.DeletedByIsNil())
+	}
+	if i.DeletedByNotNil {
+		predicates = append(predicates, pool.DeletedByNotNil())
+	}
+	if i.DeletedByEqualFold != nil {
+		predicates = append(predicates, pool.DeletedByEqualFold(*i.DeletedByEqualFold))
+	}
+	if i.DeletedByContainsFold != nil {
+		predicates = append(predicates, pool.DeletedByContainsFold(*i.DeletedByContainsFold))
+	}
 	if i.Name != nil {
 		predicates = append(predicates, pool.NameEQ(*i.Name))
 	}
@@ -1540,6 +1748,35 @@ type LoadBalancerPortWhereInput struct {
 	UpdatedAtGTE   *time.Time  `json:"updatedAtGTE,omitempty"`
 	UpdatedAtLT    *time.Time  `json:"updatedAtLT,omitempty"`
 	UpdatedAtLTE   *time.Time  `json:"updatedAtLTE,omitempty"`
+
+	// "deleted_at" field predicates.
+	DeletedAt       *time.Time  `json:"deletedAt,omitempty"`
+	DeletedAtNEQ    *time.Time  `json:"deletedAtNEQ,omitempty"`
+	DeletedAtIn     []time.Time `json:"deletedAtIn,omitempty"`
+	DeletedAtNotIn  []time.Time `json:"deletedAtNotIn,omitempty"`
+	DeletedAtGT     *time.Time  `json:"deletedAtGT,omitempty"`
+	DeletedAtGTE    *time.Time  `json:"deletedAtGTE,omitempty"`
+	DeletedAtLT     *time.Time  `json:"deletedAtLT,omitempty"`
+	DeletedAtLTE    *time.Time  `json:"deletedAtLTE,omitempty"`
+	DeletedAtIsNil  bool        `json:"deletedAtIsNil,omitempty"`
+	DeletedAtNotNil bool        `json:"deletedAtNotNil,omitempty"`
+
+	// "deleted_by" field predicates.
+	DeletedBy             *string  `json:"deletedBy,omitempty"`
+	DeletedByNEQ          *string  `json:"deletedByNEQ,omitempty"`
+	DeletedByIn           []string `json:"deletedByIn,omitempty"`
+	DeletedByNotIn        []string `json:"deletedByNotIn,omitempty"`
+	DeletedByGT           *string  `json:"deletedByGT,omitempty"`
+	DeletedByGTE          *string  `json:"deletedByGTE,omitempty"`
+	DeletedByLT           *string  `json:"deletedByLT,omitempty"`
+	DeletedByLTE          *string  `json:"deletedByLTE,omitempty"`
+	DeletedByContains     *string  `json:"deletedByContains,omitempty"`
+	DeletedByHasPrefix    *string  `json:"deletedByHasPrefix,omitempty"`
+	DeletedByHasSuffix    *string  `json:"deletedByHasSuffix,omitempty"`
+	DeletedByIsNil        bool     `json:"deletedByIsNil,omitempty"`
+	DeletedByNotNil       bool     `json:"deletedByNotNil,omitempty"`
+	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
+	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
 
 	// "created_by" field predicates.
 	CreatedBy             *string  `json:"createdBy,omitempty"`
@@ -1751,6 +1988,81 @@ func (i *LoadBalancerPortWhereInput) P() (predicate.Port, error) {
 	}
 	if i.UpdatedAtLTE != nil {
 		predicates = append(predicates, port.UpdatedAtLTE(*i.UpdatedAtLTE))
+	}
+	if i.DeletedAt != nil {
+		predicates = append(predicates, port.DeletedAtEQ(*i.DeletedAt))
+	}
+	if i.DeletedAtNEQ != nil {
+		predicates = append(predicates, port.DeletedAtNEQ(*i.DeletedAtNEQ))
+	}
+	if len(i.DeletedAtIn) > 0 {
+		predicates = append(predicates, port.DeletedAtIn(i.DeletedAtIn...))
+	}
+	if len(i.DeletedAtNotIn) > 0 {
+		predicates = append(predicates, port.DeletedAtNotIn(i.DeletedAtNotIn...))
+	}
+	if i.DeletedAtGT != nil {
+		predicates = append(predicates, port.DeletedAtGT(*i.DeletedAtGT))
+	}
+	if i.DeletedAtGTE != nil {
+		predicates = append(predicates, port.DeletedAtGTE(*i.DeletedAtGTE))
+	}
+	if i.DeletedAtLT != nil {
+		predicates = append(predicates, port.DeletedAtLT(*i.DeletedAtLT))
+	}
+	if i.DeletedAtLTE != nil {
+		predicates = append(predicates, port.DeletedAtLTE(*i.DeletedAtLTE))
+	}
+	if i.DeletedAtIsNil {
+		predicates = append(predicates, port.DeletedAtIsNil())
+	}
+	if i.DeletedAtNotNil {
+		predicates = append(predicates, port.DeletedAtNotNil())
+	}
+	if i.DeletedBy != nil {
+		predicates = append(predicates, port.DeletedByEQ(*i.DeletedBy))
+	}
+	if i.DeletedByNEQ != nil {
+		predicates = append(predicates, port.DeletedByNEQ(*i.DeletedByNEQ))
+	}
+	if len(i.DeletedByIn) > 0 {
+		predicates = append(predicates, port.DeletedByIn(i.DeletedByIn...))
+	}
+	if len(i.DeletedByNotIn) > 0 {
+		predicates = append(predicates, port.DeletedByNotIn(i.DeletedByNotIn...))
+	}
+	if i.DeletedByGT != nil {
+		predicates = append(predicates, port.DeletedByGT(*i.DeletedByGT))
+	}
+	if i.DeletedByGTE != nil {
+		predicates = append(predicates, port.DeletedByGTE(*i.DeletedByGTE))
+	}
+	if i.DeletedByLT != nil {
+		predicates = append(predicates, port.DeletedByLT(*i.DeletedByLT))
+	}
+	if i.DeletedByLTE != nil {
+		predicates = append(predicates, port.DeletedByLTE(*i.DeletedByLTE))
+	}
+	if i.DeletedByContains != nil {
+		predicates = append(predicates, port.DeletedByContains(*i.DeletedByContains))
+	}
+	if i.DeletedByHasPrefix != nil {
+		predicates = append(predicates, port.DeletedByHasPrefix(*i.DeletedByHasPrefix))
+	}
+	if i.DeletedByHasSuffix != nil {
+		predicates = append(predicates, port.DeletedByHasSuffix(*i.DeletedByHasSuffix))
+	}
+	if i.DeletedByIsNil {
+		predicates = append(predicates, port.DeletedByIsNil())
+	}
+	if i.DeletedByNotNil {
+		predicates = append(predicates, port.DeletedByNotNil())
+	}
+	if i.DeletedByEqualFold != nil {
+		predicates = append(predicates, port.DeletedByEqualFold(*i.DeletedByEqualFold))
+	}
+	if i.DeletedByContainsFold != nil {
+		predicates = append(predicates, port.DeletedByContainsFold(*i.DeletedByContainsFold))
 	}
 	if i.CreatedBy != nil {
 		predicates = append(predicates, port.CreatedByEQ(*i.CreatedBy))
@@ -1989,6 +2301,35 @@ type LoadBalancerProviderWhereInput struct {
 	UpdatedAtLT    *time.Time  `json:"updatedAtLT,omitempty"`
 	UpdatedAtLTE   *time.Time  `json:"updatedAtLTE,omitempty"`
 
+	// "deleted_at" field predicates.
+	DeletedAt       *time.Time  `json:"deletedAt,omitempty"`
+	DeletedAtNEQ    *time.Time  `json:"deletedAtNEQ,omitempty"`
+	DeletedAtIn     []time.Time `json:"deletedAtIn,omitempty"`
+	DeletedAtNotIn  []time.Time `json:"deletedAtNotIn,omitempty"`
+	DeletedAtGT     *time.Time  `json:"deletedAtGT,omitempty"`
+	DeletedAtGTE    *time.Time  `json:"deletedAtGTE,omitempty"`
+	DeletedAtLT     *time.Time  `json:"deletedAtLT,omitempty"`
+	DeletedAtLTE    *time.Time  `json:"deletedAtLTE,omitempty"`
+	DeletedAtIsNil  bool        `json:"deletedAtIsNil,omitempty"`
+	DeletedAtNotNil bool        `json:"deletedAtNotNil,omitempty"`
+
+	// "deleted_by" field predicates.
+	DeletedBy             *string  `json:"deletedBy,omitempty"`
+	DeletedByNEQ          *string  `json:"deletedByNEQ,omitempty"`
+	DeletedByIn           []string `json:"deletedByIn,omitempty"`
+	DeletedByNotIn        []string `json:"deletedByNotIn,omitempty"`
+	DeletedByGT           *string  `json:"deletedByGT,omitempty"`
+	DeletedByGTE          *string  `json:"deletedByGTE,omitempty"`
+	DeletedByLT           *string  `json:"deletedByLT,omitempty"`
+	DeletedByLTE          *string  `json:"deletedByLTE,omitempty"`
+	DeletedByContains     *string  `json:"deletedByContains,omitempty"`
+	DeletedByHasPrefix    *string  `json:"deletedByHasPrefix,omitempty"`
+	DeletedByHasSuffix    *string  `json:"deletedByHasSuffix,omitempty"`
+	DeletedByIsNil        bool     `json:"deletedByIsNil,omitempty"`
+	DeletedByNotNil       bool     `json:"deletedByNotNil,omitempty"`
+	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
+	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
+
 	// "created_by" field predicates.
 	CreatedBy             *string  `json:"createdBy,omitempty"`
 	CreatedByNEQ          *string  `json:"createdByNEQ,omitempty"`
@@ -2185,6 +2526,81 @@ func (i *LoadBalancerProviderWhereInput) P() (predicate.Provider, error) {
 	}
 	if i.UpdatedAtLTE != nil {
 		predicates = append(predicates, provider.UpdatedAtLTE(*i.UpdatedAtLTE))
+	}
+	if i.DeletedAt != nil {
+		predicates = append(predicates, provider.DeletedAtEQ(*i.DeletedAt))
+	}
+	if i.DeletedAtNEQ != nil {
+		predicates = append(predicates, provider.DeletedAtNEQ(*i.DeletedAtNEQ))
+	}
+	if len(i.DeletedAtIn) > 0 {
+		predicates = append(predicates, provider.DeletedAtIn(i.DeletedAtIn...))
+	}
+	if len(i.DeletedAtNotIn) > 0 {
+		predicates = append(predicates, provider.DeletedAtNotIn(i.DeletedAtNotIn...))
+	}
+	if i.DeletedAtGT != nil {
+		predicates = append(predicates, provider.DeletedAtGT(*i.DeletedAtGT))
+	}
+	if i.DeletedAtGTE != nil {
+		predicates = append(predicates, provider.DeletedAtGTE(*i.DeletedAtGTE))
+	}
+	if i.DeletedAtLT != nil {
+		predicates = append(predicates, provider.DeletedAtLT(*i.DeletedAtLT))
+	}
+	if i.DeletedAtLTE != nil {
+		predicates = append(predicates, provider.DeletedAtLTE(*i.DeletedAtLTE))
+	}
+	if i.DeletedAtIsNil {
+		predicates = append(predicates, provider.DeletedAtIsNil())
+	}
+	if i.DeletedAtNotNil {
+		predicates = append(predicates, provider.DeletedAtNotNil())
+	}
+	if i.DeletedBy != nil {
+		predicates = append(predicates, provider.DeletedByEQ(*i.DeletedBy))
+	}
+	if i.DeletedByNEQ != nil {
+		predicates = append(predicates, provider.DeletedByNEQ(*i.DeletedByNEQ))
+	}
+	if len(i.DeletedByIn) > 0 {
+		predicates = append(predicates, provider.DeletedByIn(i.DeletedByIn...))
+	}
+	if len(i.DeletedByNotIn) > 0 {
+		predicates = append(predicates, provider.DeletedByNotIn(i.DeletedByNotIn...))
+	}
+	if i.DeletedByGT != nil {
+		predicates = append(predicates, provider.DeletedByGT(*i.DeletedByGT))
+	}
+	if i.DeletedByGTE != nil {
+		predicates = append(predicates, provider.DeletedByGTE(*i.DeletedByGTE))
+	}
+	if i.DeletedByLT != nil {
+		predicates = append(predicates, provider.DeletedByLT(*i.DeletedByLT))
+	}
+	if i.DeletedByLTE != nil {
+		predicates = append(predicates, provider.DeletedByLTE(*i.DeletedByLTE))
+	}
+	if i.DeletedByContains != nil {
+		predicates = append(predicates, provider.DeletedByContains(*i.DeletedByContains))
+	}
+	if i.DeletedByHasPrefix != nil {
+		predicates = append(predicates, provider.DeletedByHasPrefix(*i.DeletedByHasPrefix))
+	}
+	if i.DeletedByHasSuffix != nil {
+		predicates = append(predicates, provider.DeletedByHasSuffix(*i.DeletedByHasSuffix))
+	}
+	if i.DeletedByIsNil {
+		predicates = append(predicates, provider.DeletedByIsNil())
+	}
+	if i.DeletedByNotNil {
+		predicates = append(predicates, provider.DeletedByNotNil())
+	}
+	if i.DeletedByEqualFold != nil {
+		predicates = append(predicates, provider.DeletedByEqualFold(*i.DeletedByEqualFold))
+	}
+	if i.DeletedByContainsFold != nil {
+		predicates = append(predicates, provider.DeletedByContainsFold(*i.DeletedByContainsFold))
 	}
 	if i.CreatedBy != nil {
 		predicates = append(predicates, provider.CreatedByEQ(*i.CreatedBy))

--- a/internal/ent/generated/loadbalancer.go
+++ b/internal/ent/generated/loadbalancer.go
@@ -42,6 +42,10 @@ type LoadBalancer struct {
 	CreatedBy string `json:"created_by,omitempty"`
 	// UpdatedBy holds the value of the "updated_by" field.
 	UpdatedBy string `json:"updated_by,omitempty"`
+	// DeletedAt holds the value of the "deleted_at" field.
+	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	// DeletedBy holds the value of the "deleted_by" field.
+	DeletedBy string `json:"deleted_by,omitempty"`
 	// The name of the load balancer.
 	Name string `json:"name,omitempty"`
 	// The ID for the owner for this load balancer.
@@ -100,9 +104,9 @@ func (*LoadBalancer) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case loadbalancer.FieldID, loadbalancer.FieldOwnerID, loadbalancer.FieldLocationID, loadbalancer.FieldProviderID:
 			values[i] = new(gidx.PrefixedID)
-		case loadbalancer.FieldCreatedBy, loadbalancer.FieldUpdatedBy, loadbalancer.FieldName:
+		case loadbalancer.FieldCreatedBy, loadbalancer.FieldUpdatedBy, loadbalancer.FieldDeletedBy, loadbalancer.FieldName:
 			values[i] = new(sql.NullString)
-		case loadbalancer.FieldCreatedAt, loadbalancer.FieldUpdatedAt:
+		case loadbalancer.FieldCreatedAt, loadbalancer.FieldUpdatedAt, loadbalancer.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -148,6 +152,18 @@ func (lb *LoadBalancer) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field updated_by", values[i])
 			} else if value.Valid {
 				lb.UpdatedBy = value.String
+			}
+		case loadbalancer.FieldDeletedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_at", values[i])
+			} else if value.Valid {
+				lb.DeletedAt = value.Time
+			}
+		case loadbalancer.FieldDeletedBy:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_by", values[i])
+			} else if value.Valid {
+				lb.DeletedBy = value.String
 			}
 		case loadbalancer.FieldName:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -230,6 +246,12 @@ func (lb *LoadBalancer) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("updated_by=")
 	builder.WriteString(lb.UpdatedBy)
+	builder.WriteString(", ")
+	builder.WriteString("deleted_at=")
+	builder.WriteString(lb.DeletedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("deleted_by=")
+	builder.WriteString(lb.DeletedBy)
 	builder.WriteString(", ")
 	builder.WriteString("name=")
 	builder.WriteString(lb.Name)

--- a/internal/ent/generated/loadbalancer/loadbalancer.go
+++ b/internal/ent/generated/loadbalancer/loadbalancer.go
@@ -38,6 +38,10 @@ const (
 	FieldCreatedBy = "created_by"
 	// FieldUpdatedBy holds the string denoting the updated_by field in the database.
 	FieldUpdatedBy = "updated_by"
+	// FieldDeletedAt holds the string denoting the deleted_at field in the database.
+	FieldDeletedAt = "deleted_at"
+	// FieldDeletedBy holds the string denoting the deleted_by field in the database.
+	FieldDeletedBy = "deleted_by"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
 	// FieldOwnerID holds the string denoting the owner_id field in the database.
@@ -75,6 +79,8 @@ var Columns = []string{
 	FieldUpdatedAt,
 	FieldCreatedBy,
 	FieldUpdatedBy,
+	FieldDeletedAt,
+	FieldDeletedBy,
 	FieldName,
 	FieldOwnerID,
 	FieldLocationID,
@@ -97,7 +103,8 @@ func ValidColumn(column string) bool {
 //
 //	import _ "go.infratographer.com/load-balancer-api/internal/ent/generated/runtime"
 var (
-	Hooks [1]ent.Hook
+	Hooks        [2]ent.Hook
+	Interceptors [1]ent.Interceptor
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -142,6 +149,16 @@ func ByCreatedBy(opts ...sql.OrderTermOption) OrderOption {
 // ByUpdatedBy orders the results by the updated_by field.
 func ByUpdatedBy(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUpdatedBy, opts...).ToFunc()
+}
+
+// ByDeletedAt orders the results by the deleted_at field.
+func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
+}
+
+// ByDeletedBy orders the results by the deleted_by field.
+func ByDeletedBy(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedBy, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.

--- a/internal/ent/generated/loadbalancer/where.go
+++ b/internal/ent/generated/loadbalancer/where.go
@@ -90,6 +90,16 @@ func UpdatedBy(v string) predicate.LoadBalancer {
 	return predicate.LoadBalancer(sql.FieldEQ(FieldUpdatedBy, v))
 }
 
+// DeletedAt applies equality check predicate on the "deleted_at" field. It's identical to DeletedAtEQ.
+func DeletedAt(v time.Time) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedBy applies equality check predicate on the "deleted_by" field. It's identical to DeletedByEQ.
+func DeletedBy(v string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldEQ(FieldDeletedBy, v))
+}
+
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
 func Name(v string) predicate.LoadBalancer {
 	return predicate.LoadBalancer(sql.FieldEQ(FieldName, v))
@@ -338,6 +348,131 @@ func UpdatedByEqualFold(v string) predicate.LoadBalancer {
 // UpdatedByContainsFold applies the ContainsFold predicate on the "updated_by" field.
 func UpdatedByContainsFold(v string) predicate.LoadBalancer {
 	return predicate.LoadBalancer(sql.FieldContainsFold(FieldUpdatedBy, v))
+}
+
+// DeletedAtEQ applies the EQ predicate on the "deleted_at" field.
+func DeletedAtEQ(v time.Time) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtNEQ applies the NEQ predicate on the "deleted_at" field.
+func DeletedAtNEQ(v time.Time) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldNEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtIn applies the In predicate on the "deleted_at" field.
+func DeletedAtIn(vs ...time.Time) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtNotIn applies the NotIn predicate on the "deleted_at" field.
+func DeletedAtNotIn(vs ...time.Time) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldNotIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtGT applies the GT predicate on the "deleted_at" field.
+func DeletedAtGT(v time.Time) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldGT(FieldDeletedAt, v))
+}
+
+// DeletedAtGTE applies the GTE predicate on the "deleted_at" field.
+func DeletedAtGTE(v time.Time) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldGTE(FieldDeletedAt, v))
+}
+
+// DeletedAtLT applies the LT predicate on the "deleted_at" field.
+func DeletedAtLT(v time.Time) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldLT(FieldDeletedAt, v))
+}
+
+// DeletedAtLTE applies the LTE predicate on the "deleted_at" field.
+func DeletedAtLTE(v time.Time) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldLTE(FieldDeletedAt, v))
+}
+
+// DeletedAtIsNil applies the IsNil predicate on the "deleted_at" field.
+func DeletedAtIsNil() predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldIsNull(FieldDeletedAt))
+}
+
+// DeletedAtNotNil applies the NotNil predicate on the "deleted_at" field.
+func DeletedAtNotNil() predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldNotNull(FieldDeletedAt))
+}
+
+// DeletedByEQ applies the EQ predicate on the "deleted_by" field.
+func DeletedByEQ(v string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldEQ(FieldDeletedBy, v))
+}
+
+// DeletedByNEQ applies the NEQ predicate on the "deleted_by" field.
+func DeletedByNEQ(v string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldNEQ(FieldDeletedBy, v))
+}
+
+// DeletedByIn applies the In predicate on the "deleted_by" field.
+func DeletedByIn(vs ...string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldIn(FieldDeletedBy, vs...))
+}
+
+// DeletedByNotIn applies the NotIn predicate on the "deleted_by" field.
+func DeletedByNotIn(vs ...string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldNotIn(FieldDeletedBy, vs...))
+}
+
+// DeletedByGT applies the GT predicate on the "deleted_by" field.
+func DeletedByGT(v string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldGT(FieldDeletedBy, v))
+}
+
+// DeletedByGTE applies the GTE predicate on the "deleted_by" field.
+func DeletedByGTE(v string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldGTE(FieldDeletedBy, v))
+}
+
+// DeletedByLT applies the LT predicate on the "deleted_by" field.
+func DeletedByLT(v string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldLT(FieldDeletedBy, v))
+}
+
+// DeletedByLTE applies the LTE predicate on the "deleted_by" field.
+func DeletedByLTE(v string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldLTE(FieldDeletedBy, v))
+}
+
+// DeletedByContains applies the Contains predicate on the "deleted_by" field.
+func DeletedByContains(v string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldContains(FieldDeletedBy, v))
+}
+
+// DeletedByHasPrefix applies the HasPrefix predicate on the "deleted_by" field.
+func DeletedByHasPrefix(v string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldHasPrefix(FieldDeletedBy, v))
+}
+
+// DeletedByHasSuffix applies the HasSuffix predicate on the "deleted_by" field.
+func DeletedByHasSuffix(v string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldHasSuffix(FieldDeletedBy, v))
+}
+
+// DeletedByIsNil applies the IsNil predicate on the "deleted_by" field.
+func DeletedByIsNil() predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldIsNull(FieldDeletedBy))
+}
+
+// DeletedByNotNil applies the NotNil predicate on the "deleted_by" field.
+func DeletedByNotNil() predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldNotNull(FieldDeletedBy))
+}
+
+// DeletedByEqualFold applies the EqualFold predicate on the "deleted_by" field.
+func DeletedByEqualFold(v string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldEqualFold(FieldDeletedBy, v))
+}
+
+// DeletedByContainsFold applies the ContainsFold predicate on the "deleted_by" field.
+func DeletedByContainsFold(v string) predicate.LoadBalancer {
+	return predicate.LoadBalancer(sql.FieldContainsFold(FieldDeletedBy, v))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.

--- a/internal/ent/generated/loadbalancer_create.go
+++ b/internal/ent/generated/loadbalancer_create.go
@@ -93,6 +93,34 @@ func (lbc *LoadBalancerCreate) SetNillableUpdatedBy(s *string) *LoadBalancerCrea
 	return lbc
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (lbc *LoadBalancerCreate) SetDeletedAt(t time.Time) *LoadBalancerCreate {
+	lbc.mutation.SetDeletedAt(t)
+	return lbc
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (lbc *LoadBalancerCreate) SetNillableDeletedAt(t *time.Time) *LoadBalancerCreate {
+	if t != nil {
+		lbc.SetDeletedAt(*t)
+	}
+	return lbc
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (lbc *LoadBalancerCreate) SetDeletedBy(s string) *LoadBalancerCreate {
+	lbc.mutation.SetDeletedBy(s)
+	return lbc
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (lbc *LoadBalancerCreate) SetNillableDeletedBy(s *string) *LoadBalancerCreate {
+	if s != nil {
+		lbc.SetDeletedBy(*s)
+	}
+	return lbc
+}
+
 // SetName sets the "name" field.
 func (lbc *LoadBalancerCreate) SetName(s string) *LoadBalancerCreate {
 	lbc.mutation.SetName(s)
@@ -305,6 +333,14 @@ func (lbc *LoadBalancerCreate) createSpec() (*LoadBalancer, *sqlgraph.CreateSpec
 	if value, ok := lbc.mutation.UpdatedBy(); ok {
 		_spec.SetField(loadbalancer.FieldUpdatedBy, field.TypeString, value)
 		_node.UpdatedBy = value
+	}
+	if value, ok := lbc.mutation.DeletedAt(); ok {
+		_spec.SetField(loadbalancer.FieldDeletedAt, field.TypeTime, value)
+		_node.DeletedAt = value
+	}
+	if value, ok := lbc.mutation.DeletedBy(); ok {
+		_spec.SetField(loadbalancer.FieldDeletedBy, field.TypeString, value)
+		_node.DeletedBy = value
 	}
 	if value, ok := lbc.mutation.Name(); ok {
 		_spec.SetField(loadbalancer.FieldName, field.TypeString, value)

--- a/internal/ent/generated/loadbalancer_update.go
+++ b/internal/ent/generated/loadbalancer_update.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -60,6 +61,46 @@ func (lbu *LoadBalancerUpdate) SetNillableUpdatedBy(s *string) *LoadBalancerUpda
 // ClearUpdatedBy clears the value of the "updated_by" field.
 func (lbu *LoadBalancerUpdate) ClearUpdatedBy() *LoadBalancerUpdate {
 	lbu.mutation.ClearUpdatedBy()
+	return lbu
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (lbu *LoadBalancerUpdate) SetDeletedAt(t time.Time) *LoadBalancerUpdate {
+	lbu.mutation.SetDeletedAt(t)
+	return lbu
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (lbu *LoadBalancerUpdate) SetNillableDeletedAt(t *time.Time) *LoadBalancerUpdate {
+	if t != nil {
+		lbu.SetDeletedAt(*t)
+	}
+	return lbu
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (lbu *LoadBalancerUpdate) ClearDeletedAt() *LoadBalancerUpdate {
+	lbu.mutation.ClearDeletedAt()
+	return lbu
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (lbu *LoadBalancerUpdate) SetDeletedBy(s string) *LoadBalancerUpdate {
+	lbu.mutation.SetDeletedBy(s)
+	return lbu
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (lbu *LoadBalancerUpdate) SetNillableDeletedBy(s *string) *LoadBalancerUpdate {
+	if s != nil {
+		lbu.SetDeletedBy(*s)
+	}
+	return lbu
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (lbu *LoadBalancerUpdate) ClearDeletedBy() *LoadBalancerUpdate {
+	lbu.mutation.ClearDeletedBy()
 	return lbu
 }
 
@@ -189,6 +230,18 @@ func (lbu *LoadBalancerUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if lbu.mutation.UpdatedByCleared() {
 		_spec.ClearField(loadbalancer.FieldUpdatedBy, field.TypeString)
 	}
+	if value, ok := lbu.mutation.DeletedAt(); ok {
+		_spec.SetField(loadbalancer.FieldDeletedAt, field.TypeTime, value)
+	}
+	if lbu.mutation.DeletedAtCleared() {
+		_spec.ClearField(loadbalancer.FieldDeletedAt, field.TypeTime)
+	}
+	if value, ok := lbu.mutation.DeletedBy(); ok {
+		_spec.SetField(loadbalancer.FieldDeletedBy, field.TypeString, value)
+	}
+	if lbu.mutation.DeletedByCleared() {
+		_spec.ClearField(loadbalancer.FieldDeletedBy, field.TypeString)
+	}
 	if value, ok := lbu.mutation.Name(); ok {
 		_spec.SetField(loadbalancer.FieldName, field.TypeString, value)
 	}
@@ -274,6 +327,46 @@ func (lbuo *LoadBalancerUpdateOne) SetNillableUpdatedBy(s *string) *LoadBalancer
 // ClearUpdatedBy clears the value of the "updated_by" field.
 func (lbuo *LoadBalancerUpdateOne) ClearUpdatedBy() *LoadBalancerUpdateOne {
 	lbuo.mutation.ClearUpdatedBy()
+	return lbuo
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (lbuo *LoadBalancerUpdateOne) SetDeletedAt(t time.Time) *LoadBalancerUpdateOne {
+	lbuo.mutation.SetDeletedAt(t)
+	return lbuo
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (lbuo *LoadBalancerUpdateOne) SetNillableDeletedAt(t *time.Time) *LoadBalancerUpdateOne {
+	if t != nil {
+		lbuo.SetDeletedAt(*t)
+	}
+	return lbuo
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (lbuo *LoadBalancerUpdateOne) ClearDeletedAt() *LoadBalancerUpdateOne {
+	lbuo.mutation.ClearDeletedAt()
+	return lbuo
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (lbuo *LoadBalancerUpdateOne) SetDeletedBy(s string) *LoadBalancerUpdateOne {
+	lbuo.mutation.SetDeletedBy(s)
+	return lbuo
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (lbuo *LoadBalancerUpdateOne) SetNillableDeletedBy(s *string) *LoadBalancerUpdateOne {
+	if s != nil {
+		lbuo.SetDeletedBy(*s)
+	}
+	return lbuo
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (lbuo *LoadBalancerUpdateOne) ClearDeletedBy() *LoadBalancerUpdateOne {
+	lbuo.mutation.ClearDeletedBy()
 	return lbuo
 }
 
@@ -432,6 +525,18 @@ func (lbuo *LoadBalancerUpdateOne) sqlSave(ctx context.Context) (_node *LoadBala
 	}
 	if lbuo.mutation.UpdatedByCleared() {
 		_spec.ClearField(loadbalancer.FieldUpdatedBy, field.TypeString)
+	}
+	if value, ok := lbuo.mutation.DeletedAt(); ok {
+		_spec.SetField(loadbalancer.FieldDeletedAt, field.TypeTime, value)
+	}
+	if lbuo.mutation.DeletedAtCleared() {
+		_spec.ClearField(loadbalancer.FieldDeletedAt, field.TypeTime)
+	}
+	if value, ok := lbuo.mutation.DeletedBy(); ok {
+		_spec.SetField(loadbalancer.FieldDeletedBy, field.TypeString, value)
+	}
+	if lbuo.mutation.DeletedByCleared() {
+		_spec.ClearField(loadbalancer.FieldDeletedBy, field.TypeString)
 	}
 	if value, ok := lbuo.mutation.Name(); ok {
 		_spec.SetField(loadbalancer.FieldName, field.TypeString, value)

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -82,6 +82,8 @@ var (
 		{Name: "id", Type: field.TypeString, Unique: true},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
+		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
+		{Name: "deleted_by", Type: field.TypeString, Nullable: true},
 		{Name: "created_by", Type: field.TypeString, Nullable: true},
 		{Name: "updated_by", Type: field.TypeString, Nullable: true},
 		{Name: "name", Type: field.TypeString},
@@ -99,7 +101,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "origins_pools_pool",
-				Columns:    []*schema.Column{OriginsColumns[10]},
+				Columns:    []*schema.Column{OriginsColumns[12]},
 				RefColumns: []*schema.Column{PoolsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -118,7 +120,7 @@ var (
 			{
 				Name:    "origin_pool_id",
 				Unique:  false,
-				Columns: []*schema.Column{OriginsColumns[10]},
+				Columns: []*schema.Column{OriginsColumns[12]},
 			},
 		},
 	}
@@ -129,6 +131,8 @@ var (
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "created_by", Type: field.TypeString, Nullable: true},
 		{Name: "updated_by", Type: field.TypeString, Nullable: true},
+		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
+		{Name: "deleted_by", Type: field.TypeString, Nullable: true},
 		{Name: "name", Type: field.TypeString},
 		{Name: "protocol", Type: field.TypeEnum, Enums: []string{"tcp", "udp"}},
 		{Name: "owner_id", Type: field.TypeString},
@@ -152,7 +156,7 @@ var (
 			{
 				Name:    "pool_owner_id",
 				Unique:  false,
-				Columns: []*schema.Column{PoolsColumns[7]},
+				Columns: []*schema.Column{PoolsColumns[9]},
 			},
 		},
 	}
@@ -161,6 +165,8 @@ var (
 		{Name: "id", Type: field.TypeString, Unique: true},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
+		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
+		{Name: "deleted_by", Type: field.TypeString, Nullable: true},
 		{Name: "created_by", Type: field.TypeString, Nullable: true},
 		{Name: "updated_by", Type: field.TypeString, Nullable: true},
 		{Name: "number", Type: field.TypeInt},
@@ -175,7 +181,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "ports_load_balancers_load_balancer",
-				Columns:    []*schema.Column{PortsColumns[7]},
+				Columns:    []*schema.Column{PortsColumns[9]},
 				RefColumns: []*schema.Column{LoadBalancersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -194,12 +200,12 @@ var (
 			{
 				Name:    "port_load_balancer_id",
 				Unique:  false,
-				Columns: []*schema.Column{PortsColumns[7]},
+				Columns: []*schema.Column{PortsColumns[9]},
 			},
 			{
 				Name:    "port_load_balancer_id_number",
 				Unique:  true,
-				Columns: []*schema.Column{PortsColumns[7], PortsColumns[5]},
+				Columns: []*schema.Column{PortsColumns[9], PortsColumns[7]},
 			},
 		},
 	}
@@ -208,6 +214,8 @@ var (
 		{Name: "id", Type: field.TypeString, Unique: true},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
+		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
+		{Name: "deleted_by", Type: field.TypeString, Nullable: true},
 		{Name: "created_by", Type: field.TypeString, Nullable: true},
 		{Name: "updated_by", Type: field.TypeString, Nullable: true},
 		{Name: "name", Type: field.TypeString},
@@ -232,7 +240,7 @@ var (
 			{
 				Name:    "provider_owner_id",
 				Unique:  false,
-				Columns: []*schema.Column{ProvidersColumns[6]},
+				Columns: []*schema.Column{ProvidersColumns[8]},
 			},
 		},
 	}

--- a/internal/ent/generated/migrate/schema.go
+++ b/internal/ent/generated/migrate/schema.go
@@ -29,6 +29,8 @@ var (
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "created_by", Type: field.TypeString, Nullable: true},
 		{Name: "updated_by", Type: field.TypeString, Nullable: true},
+		{Name: "deleted_at", Type: field.TypeTime, Nullable: true},
+		{Name: "deleted_by", Type: field.TypeString, Nullable: true},
 		{Name: "name", Type: field.TypeString, Size: 2147483647},
 		{Name: "owner_id", Type: field.TypeString},
 		{Name: "location_id", Type: field.TypeString},
@@ -42,7 +44,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "load_balancers_providers_provider",
-				Columns:    []*schema.Column{LoadBalancersColumns[8]},
+				Columns:    []*schema.Column{LoadBalancersColumns[10]},
 				RefColumns: []*schema.Column{ProvidersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -61,17 +63,17 @@ var (
 			{
 				Name:    "loadbalancer_provider_id",
 				Unique:  false,
-				Columns: []*schema.Column{LoadBalancersColumns[8]},
+				Columns: []*schema.Column{LoadBalancersColumns[10]},
 			},
 			{
 				Name:    "loadbalancer_location_id",
 				Unique:  false,
-				Columns: []*schema.Column{LoadBalancersColumns[7]},
+				Columns: []*schema.Column{LoadBalancersColumns[9]},
 			},
 			{
 				Name:    "loadbalancer_owner_id",
 				Unique:  false,
-				Columns: []*schema.Column{LoadBalancersColumns[6]},
+				Columns: []*schema.Column{LoadBalancersColumns[8]},
 			},
 		},
 	}

--- a/internal/ent/generated/mutation.go
+++ b/internal/ent/generated/mutation.go
@@ -1094,6 +1094,8 @@ type OriginMutation struct {
 	id             *gidx.PrefixedID
 	created_at     *time.Time
 	updated_at     *time.Time
+	deleted_at     *time.Time
+	deleted_by     *string
 	created_by     *string
 	updated_by     *string
 	name           *string
@@ -1285,6 +1287,104 @@ func (m *OriginMutation) OldUpdatedAt(ctx context.Context) (v time.Time, err err
 // ResetUpdatedAt resets all changes to the "updated_at" field.
 func (m *OriginMutation) ResetUpdatedAt() {
 	m.updated_at = nil
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (m *OriginMutation) SetDeletedAt(t time.Time) {
+	m.deleted_at = &t
+}
+
+// DeletedAt returns the value of the "deleted_at" field in the mutation.
+func (m *OriginMutation) DeletedAt() (r time.Time, exists bool) {
+	v := m.deleted_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedAt returns the old "deleted_at" field's value of the Origin entity.
+// If the Origin object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *OriginMutation) OldDeletedAt(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedAt: %w", err)
+	}
+	return oldValue.DeletedAt, nil
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (m *OriginMutation) ClearDeletedAt() {
+	m.deleted_at = nil
+	m.clearedFields[origin.FieldDeletedAt] = struct{}{}
+}
+
+// DeletedAtCleared returns if the "deleted_at" field was cleared in this mutation.
+func (m *OriginMutation) DeletedAtCleared() bool {
+	_, ok := m.clearedFields[origin.FieldDeletedAt]
+	return ok
+}
+
+// ResetDeletedAt resets all changes to the "deleted_at" field.
+func (m *OriginMutation) ResetDeletedAt() {
+	m.deleted_at = nil
+	delete(m.clearedFields, origin.FieldDeletedAt)
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (m *OriginMutation) SetDeletedBy(s string) {
+	m.deleted_by = &s
+}
+
+// DeletedBy returns the value of the "deleted_by" field in the mutation.
+func (m *OriginMutation) DeletedBy() (r string, exists bool) {
+	v := m.deleted_by
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedBy returns the old "deleted_by" field's value of the Origin entity.
+// If the Origin object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *OriginMutation) OldDeletedBy(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedBy is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedBy requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedBy: %w", err)
+	}
+	return oldValue.DeletedBy, nil
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (m *OriginMutation) ClearDeletedBy() {
+	m.deleted_by = nil
+	m.clearedFields[origin.FieldDeletedBy] = struct{}{}
+}
+
+// DeletedByCleared returns if the "deleted_by" field was cleared in this mutation.
+func (m *OriginMutation) DeletedByCleared() bool {
+	_, ok := m.clearedFields[origin.FieldDeletedBy]
+	return ok
+}
+
+// ResetDeletedBy resets all changes to the "deleted_by" field.
+func (m *OriginMutation) ResetDeletedBy() {
+	m.deleted_by = nil
+	delete(m.clearedFields, origin.FieldDeletedBy)
 }
 
 // SetCreatedBy sets the "created_by" field.
@@ -1702,12 +1802,18 @@ func (m *OriginMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *OriginMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 12)
 	if m.created_at != nil {
 		fields = append(fields, origin.FieldCreatedAt)
 	}
 	if m.updated_at != nil {
 		fields = append(fields, origin.FieldUpdatedAt)
+	}
+	if m.deleted_at != nil {
+		fields = append(fields, origin.FieldDeletedAt)
+	}
+	if m.deleted_by != nil {
+		fields = append(fields, origin.FieldDeletedBy)
 	}
 	if m.created_by != nil {
 		fields = append(fields, origin.FieldCreatedBy)
@@ -1745,6 +1851,10 @@ func (m *OriginMutation) Field(name string) (ent.Value, bool) {
 		return m.CreatedAt()
 	case origin.FieldUpdatedAt:
 		return m.UpdatedAt()
+	case origin.FieldDeletedAt:
+		return m.DeletedAt()
+	case origin.FieldDeletedBy:
+		return m.DeletedBy()
 	case origin.FieldCreatedBy:
 		return m.CreatedBy()
 	case origin.FieldUpdatedBy:
@@ -1774,6 +1884,10 @@ func (m *OriginMutation) OldField(ctx context.Context, name string) (ent.Value, 
 		return m.OldCreatedAt(ctx)
 	case origin.FieldUpdatedAt:
 		return m.OldUpdatedAt(ctx)
+	case origin.FieldDeletedAt:
+		return m.OldDeletedAt(ctx)
+	case origin.FieldDeletedBy:
+		return m.OldDeletedBy(ctx)
 	case origin.FieldCreatedBy:
 		return m.OldCreatedBy(ctx)
 	case origin.FieldUpdatedBy:
@@ -1812,6 +1926,20 @@ func (m *OriginMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUpdatedAt(v)
+		return nil
+	case origin.FieldDeletedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedAt(v)
+		return nil
+	case origin.FieldDeletedBy:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedBy(v)
 		return nil
 	case origin.FieldCreatedBy:
 		v, ok := value.(string)
@@ -1926,6 +2054,12 @@ func (m *OriginMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *OriginMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(origin.FieldDeletedAt) {
+		fields = append(fields, origin.FieldDeletedAt)
+	}
+	if m.FieldCleared(origin.FieldDeletedBy) {
+		fields = append(fields, origin.FieldDeletedBy)
+	}
 	if m.FieldCleared(origin.FieldCreatedBy) {
 		fields = append(fields, origin.FieldCreatedBy)
 	}
@@ -1946,6 +2080,12 @@ func (m *OriginMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *OriginMutation) ClearField(name string) error {
 	switch name {
+	case origin.FieldDeletedAt:
+		m.ClearDeletedAt()
+		return nil
+	case origin.FieldDeletedBy:
+		m.ClearDeletedBy()
+		return nil
 	case origin.FieldCreatedBy:
 		m.ClearCreatedBy()
 		return nil
@@ -1965,6 +2105,12 @@ func (m *OriginMutation) ResetField(name string) error {
 		return nil
 	case origin.FieldUpdatedAt:
 		m.ResetUpdatedAt()
+		return nil
+	case origin.FieldDeletedAt:
+		m.ResetDeletedAt()
+		return nil
+	case origin.FieldDeletedBy:
+		m.ResetDeletedBy()
 		return nil
 	case origin.FieldCreatedBy:
 		m.ResetCreatedBy()
@@ -2078,6 +2224,8 @@ type PoolMutation struct {
 	updated_at     *time.Time
 	created_by     *string
 	updated_by     *string
+	deleted_at     *time.Time
+	deleted_by     *string
 	name           *string
 	protocol       *pool.Protocol
 	owner_id       *gidx.PrefixedID
@@ -2367,6 +2515,104 @@ func (m *PoolMutation) ResetUpdatedBy() {
 	delete(m.clearedFields, pool.FieldUpdatedBy)
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (m *PoolMutation) SetDeletedAt(t time.Time) {
+	m.deleted_at = &t
+}
+
+// DeletedAt returns the value of the "deleted_at" field in the mutation.
+func (m *PoolMutation) DeletedAt() (r time.Time, exists bool) {
+	v := m.deleted_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedAt returns the old "deleted_at" field's value of the Pool entity.
+// If the Pool object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PoolMutation) OldDeletedAt(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedAt: %w", err)
+	}
+	return oldValue.DeletedAt, nil
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (m *PoolMutation) ClearDeletedAt() {
+	m.deleted_at = nil
+	m.clearedFields[pool.FieldDeletedAt] = struct{}{}
+}
+
+// DeletedAtCleared returns if the "deleted_at" field was cleared in this mutation.
+func (m *PoolMutation) DeletedAtCleared() bool {
+	_, ok := m.clearedFields[pool.FieldDeletedAt]
+	return ok
+}
+
+// ResetDeletedAt resets all changes to the "deleted_at" field.
+func (m *PoolMutation) ResetDeletedAt() {
+	m.deleted_at = nil
+	delete(m.clearedFields, pool.FieldDeletedAt)
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (m *PoolMutation) SetDeletedBy(s string) {
+	m.deleted_by = &s
+}
+
+// DeletedBy returns the value of the "deleted_by" field in the mutation.
+func (m *PoolMutation) DeletedBy() (r string, exists bool) {
+	v := m.deleted_by
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedBy returns the old "deleted_by" field's value of the Pool entity.
+// If the Pool object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PoolMutation) OldDeletedBy(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedBy is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedBy requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedBy: %w", err)
+	}
+	return oldValue.DeletedBy, nil
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (m *PoolMutation) ClearDeletedBy() {
+	m.deleted_by = nil
+	m.clearedFields[pool.FieldDeletedBy] = struct{}{}
+}
+
+// DeletedByCleared returns if the "deleted_by" field was cleared in this mutation.
+func (m *PoolMutation) DeletedByCleared() bool {
+	_, ok := m.clearedFields[pool.FieldDeletedBy]
+	return ok
+}
+
+// ResetDeletedBy resets all changes to the "deleted_by" field.
+func (m *PoolMutation) ResetDeletedBy() {
+	m.deleted_by = nil
+	delete(m.clearedFields, pool.FieldDeletedBy)
+}
+
 // SetName sets the "name" field.
 func (m *PoolMutation) SetName(s string) {
 	m.name = &s
@@ -2617,7 +2863,7 @@ func (m *PoolMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PoolMutation) Fields() []string {
-	fields := make([]string, 0, 7)
+	fields := make([]string, 0, 9)
 	if m.created_at != nil {
 		fields = append(fields, pool.FieldCreatedAt)
 	}
@@ -2629,6 +2875,12 @@ func (m *PoolMutation) Fields() []string {
 	}
 	if m.updated_by != nil {
 		fields = append(fields, pool.FieldUpdatedBy)
+	}
+	if m.deleted_at != nil {
+		fields = append(fields, pool.FieldDeletedAt)
+	}
+	if m.deleted_by != nil {
+		fields = append(fields, pool.FieldDeletedBy)
 	}
 	if m.name != nil {
 		fields = append(fields, pool.FieldName)
@@ -2655,6 +2907,10 @@ func (m *PoolMutation) Field(name string) (ent.Value, bool) {
 		return m.CreatedBy()
 	case pool.FieldUpdatedBy:
 		return m.UpdatedBy()
+	case pool.FieldDeletedAt:
+		return m.DeletedAt()
+	case pool.FieldDeletedBy:
+		return m.DeletedBy()
 	case pool.FieldName:
 		return m.Name()
 	case pool.FieldProtocol:
@@ -2678,6 +2934,10 @@ func (m *PoolMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldCreatedBy(ctx)
 	case pool.FieldUpdatedBy:
 		return m.OldUpdatedBy(ctx)
+	case pool.FieldDeletedAt:
+		return m.OldDeletedAt(ctx)
+	case pool.FieldDeletedBy:
+		return m.OldDeletedBy(ctx)
 	case pool.FieldName:
 		return m.OldName(ctx)
 	case pool.FieldProtocol:
@@ -2720,6 +2980,20 @@ func (m *PoolMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUpdatedBy(v)
+		return nil
+	case pool.FieldDeletedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedAt(v)
+		return nil
+	case pool.FieldDeletedBy:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedBy(v)
 		return nil
 	case pool.FieldName:
 		v, ok := value.(string)
@@ -2778,6 +3052,12 @@ func (m *PoolMutation) ClearedFields() []string {
 	if m.FieldCleared(pool.FieldUpdatedBy) {
 		fields = append(fields, pool.FieldUpdatedBy)
 	}
+	if m.FieldCleared(pool.FieldDeletedAt) {
+		fields = append(fields, pool.FieldDeletedAt)
+	}
+	if m.FieldCleared(pool.FieldDeletedBy) {
+		fields = append(fields, pool.FieldDeletedBy)
+	}
 	return fields
 }
 
@@ -2798,6 +3078,12 @@ func (m *PoolMutation) ClearField(name string) error {
 	case pool.FieldUpdatedBy:
 		m.ClearUpdatedBy()
 		return nil
+	case pool.FieldDeletedAt:
+		m.ClearDeletedAt()
+		return nil
+	case pool.FieldDeletedBy:
+		m.ClearDeletedBy()
+		return nil
 	}
 	return fmt.Errorf("unknown Pool nullable field %s", name)
 }
@@ -2817,6 +3103,12 @@ func (m *PoolMutation) ResetField(name string) error {
 		return nil
 	case pool.FieldUpdatedBy:
 		m.ResetUpdatedBy()
+		return nil
+	case pool.FieldDeletedAt:
+		m.ResetDeletedAt()
+		return nil
+	case pool.FieldDeletedBy:
+		m.ResetDeletedBy()
 		return nil
 	case pool.FieldName:
 		m.ResetName()
@@ -2949,6 +3241,8 @@ type PortMutation struct {
 	id                   *gidx.PrefixedID
 	created_at           *time.Time
 	updated_at           *time.Time
+	deleted_at           *time.Time
+	deleted_by           *string
 	created_by           *string
 	updated_by           *string
 	number               *int
@@ -3139,6 +3433,104 @@ func (m *PortMutation) OldUpdatedAt(ctx context.Context) (v time.Time, err error
 // ResetUpdatedAt resets all changes to the "updated_at" field.
 func (m *PortMutation) ResetUpdatedAt() {
 	m.updated_at = nil
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (m *PortMutation) SetDeletedAt(t time.Time) {
+	m.deleted_at = &t
+}
+
+// DeletedAt returns the value of the "deleted_at" field in the mutation.
+func (m *PortMutation) DeletedAt() (r time.Time, exists bool) {
+	v := m.deleted_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedAt returns the old "deleted_at" field's value of the Port entity.
+// If the Port object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PortMutation) OldDeletedAt(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedAt: %w", err)
+	}
+	return oldValue.DeletedAt, nil
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (m *PortMutation) ClearDeletedAt() {
+	m.deleted_at = nil
+	m.clearedFields[port.FieldDeletedAt] = struct{}{}
+}
+
+// DeletedAtCleared returns if the "deleted_at" field was cleared in this mutation.
+func (m *PortMutation) DeletedAtCleared() bool {
+	_, ok := m.clearedFields[port.FieldDeletedAt]
+	return ok
+}
+
+// ResetDeletedAt resets all changes to the "deleted_at" field.
+func (m *PortMutation) ResetDeletedAt() {
+	m.deleted_at = nil
+	delete(m.clearedFields, port.FieldDeletedAt)
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (m *PortMutation) SetDeletedBy(s string) {
+	m.deleted_by = &s
+}
+
+// DeletedBy returns the value of the "deleted_by" field in the mutation.
+func (m *PortMutation) DeletedBy() (r string, exists bool) {
+	v := m.deleted_by
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedBy returns the old "deleted_by" field's value of the Port entity.
+// If the Port object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PortMutation) OldDeletedBy(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedBy is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedBy requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedBy: %w", err)
+	}
+	return oldValue.DeletedBy, nil
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (m *PortMutation) ClearDeletedBy() {
+	m.deleted_by = nil
+	m.clearedFields[port.FieldDeletedBy] = struct{}{}
+}
+
+// DeletedByCleared returns if the "deleted_by" field was cleared in this mutation.
+func (m *PortMutation) DeletedByCleared() bool {
+	_, ok := m.clearedFields[port.FieldDeletedBy]
+	return ok
+}
+
+// ResetDeletedBy resets all changes to the "deleted_by" field.
+func (m *PortMutation) ResetDeletedBy() {
+	m.deleted_by = nil
+	delete(m.clearedFields, port.FieldDeletedBy)
 }
 
 // SetCreatedBy sets the "created_by" field.
@@ -3482,12 +3874,18 @@ func (m *PortMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PortMutation) Fields() []string {
-	fields := make([]string, 0, 7)
+	fields := make([]string, 0, 9)
 	if m.created_at != nil {
 		fields = append(fields, port.FieldCreatedAt)
 	}
 	if m.updated_at != nil {
 		fields = append(fields, port.FieldUpdatedAt)
+	}
+	if m.deleted_at != nil {
+		fields = append(fields, port.FieldDeletedAt)
+	}
+	if m.deleted_by != nil {
+		fields = append(fields, port.FieldDeletedBy)
 	}
 	if m.created_by != nil {
 		fields = append(fields, port.FieldCreatedBy)
@@ -3516,6 +3914,10 @@ func (m *PortMutation) Field(name string) (ent.Value, bool) {
 		return m.CreatedAt()
 	case port.FieldUpdatedAt:
 		return m.UpdatedAt()
+	case port.FieldDeletedAt:
+		return m.DeletedAt()
+	case port.FieldDeletedBy:
+		return m.DeletedBy()
 	case port.FieldCreatedBy:
 		return m.CreatedBy()
 	case port.FieldUpdatedBy:
@@ -3539,6 +3941,10 @@ func (m *PortMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldCreatedAt(ctx)
 	case port.FieldUpdatedAt:
 		return m.OldUpdatedAt(ctx)
+	case port.FieldDeletedAt:
+		return m.OldDeletedAt(ctx)
+	case port.FieldDeletedBy:
+		return m.OldDeletedBy(ctx)
 	case port.FieldCreatedBy:
 		return m.OldCreatedBy(ctx)
 	case port.FieldUpdatedBy:
@@ -3571,6 +3977,20 @@ func (m *PortMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUpdatedAt(v)
+		return nil
+	case port.FieldDeletedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedAt(v)
+		return nil
+	case port.FieldDeletedBy:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedBy(v)
 		return nil
 	case port.FieldCreatedBy:
 		v, ok := value.(string)
@@ -3652,6 +4072,12 @@ func (m *PortMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *PortMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(port.FieldDeletedAt) {
+		fields = append(fields, port.FieldDeletedAt)
+	}
+	if m.FieldCleared(port.FieldDeletedBy) {
+		fields = append(fields, port.FieldDeletedBy)
+	}
 	if m.FieldCleared(port.FieldCreatedBy) {
 		fields = append(fields, port.FieldCreatedBy)
 	}
@@ -3672,6 +4098,12 @@ func (m *PortMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *PortMutation) ClearField(name string) error {
 	switch name {
+	case port.FieldDeletedAt:
+		m.ClearDeletedAt()
+		return nil
+	case port.FieldDeletedBy:
+		m.ClearDeletedBy()
+		return nil
 	case port.FieldCreatedBy:
 		m.ClearCreatedBy()
 		return nil
@@ -3691,6 +4123,12 @@ func (m *PortMutation) ResetField(name string) error {
 		return nil
 	case port.FieldUpdatedAt:
 		m.ResetUpdatedAt()
+		return nil
+	case port.FieldDeletedAt:
+		m.ResetDeletedAt()
+		return nil
+	case port.FieldDeletedBy:
+		m.ResetDeletedBy()
 		return nil
 	case port.FieldCreatedBy:
 		m.ResetCreatedBy()
@@ -3821,6 +4259,8 @@ type ProviderMutation struct {
 	id                    *gidx.PrefixedID
 	created_at            *time.Time
 	updated_at            *time.Time
+	deleted_at            *time.Time
+	deleted_by            *string
 	created_by            *string
 	updated_by            *string
 	name                  *string
@@ -4008,6 +4448,104 @@ func (m *ProviderMutation) OldUpdatedAt(ctx context.Context) (v time.Time, err e
 // ResetUpdatedAt resets all changes to the "updated_at" field.
 func (m *ProviderMutation) ResetUpdatedAt() {
 	m.updated_at = nil
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (m *ProviderMutation) SetDeletedAt(t time.Time) {
+	m.deleted_at = &t
+}
+
+// DeletedAt returns the value of the "deleted_at" field in the mutation.
+func (m *ProviderMutation) DeletedAt() (r time.Time, exists bool) {
+	v := m.deleted_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedAt returns the old "deleted_at" field's value of the Provider entity.
+// If the Provider object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ProviderMutation) OldDeletedAt(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedAt: %w", err)
+	}
+	return oldValue.DeletedAt, nil
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (m *ProviderMutation) ClearDeletedAt() {
+	m.deleted_at = nil
+	m.clearedFields[provider.FieldDeletedAt] = struct{}{}
+}
+
+// DeletedAtCleared returns if the "deleted_at" field was cleared in this mutation.
+func (m *ProviderMutation) DeletedAtCleared() bool {
+	_, ok := m.clearedFields[provider.FieldDeletedAt]
+	return ok
+}
+
+// ResetDeletedAt resets all changes to the "deleted_at" field.
+func (m *ProviderMutation) ResetDeletedAt() {
+	m.deleted_at = nil
+	delete(m.clearedFields, provider.FieldDeletedAt)
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (m *ProviderMutation) SetDeletedBy(s string) {
+	m.deleted_by = &s
+}
+
+// DeletedBy returns the value of the "deleted_by" field in the mutation.
+func (m *ProviderMutation) DeletedBy() (r string, exists bool) {
+	v := m.deleted_by
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedBy returns the old "deleted_by" field's value of the Provider entity.
+// If the Provider object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ProviderMutation) OldDeletedBy(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedBy is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedBy requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedBy: %w", err)
+	}
+	return oldValue.DeletedBy, nil
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (m *ProviderMutation) ClearDeletedBy() {
+	m.deleted_by = nil
+	m.clearedFields[provider.FieldDeletedBy] = struct{}{}
+}
+
+// DeletedByCleared returns if the "deleted_by" field was cleared in this mutation.
+func (m *ProviderMutation) DeletedByCleared() bool {
+	_, ok := m.clearedFields[provider.FieldDeletedBy]
+	return ok
+}
+
+// ResetDeletedBy resets all changes to the "deleted_by" field.
+func (m *ProviderMutation) ResetDeletedBy() {
+	m.deleted_by = nil
+	delete(m.clearedFields, provider.FieldDeletedBy)
 }
 
 // SetCreatedBy sets the "created_by" field.
@@ -4268,12 +4806,18 @@ func (m *ProviderMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ProviderMutation) Fields() []string {
-	fields := make([]string, 0, 6)
+	fields := make([]string, 0, 8)
 	if m.created_at != nil {
 		fields = append(fields, provider.FieldCreatedAt)
 	}
 	if m.updated_at != nil {
 		fields = append(fields, provider.FieldUpdatedAt)
+	}
+	if m.deleted_at != nil {
+		fields = append(fields, provider.FieldDeletedAt)
+	}
+	if m.deleted_by != nil {
+		fields = append(fields, provider.FieldDeletedBy)
 	}
 	if m.created_by != nil {
 		fields = append(fields, provider.FieldCreatedBy)
@@ -4299,6 +4843,10 @@ func (m *ProviderMutation) Field(name string) (ent.Value, bool) {
 		return m.CreatedAt()
 	case provider.FieldUpdatedAt:
 		return m.UpdatedAt()
+	case provider.FieldDeletedAt:
+		return m.DeletedAt()
+	case provider.FieldDeletedBy:
+		return m.DeletedBy()
 	case provider.FieldCreatedBy:
 		return m.CreatedBy()
 	case provider.FieldUpdatedBy:
@@ -4320,6 +4868,10 @@ func (m *ProviderMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldCreatedAt(ctx)
 	case provider.FieldUpdatedAt:
 		return m.OldUpdatedAt(ctx)
+	case provider.FieldDeletedAt:
+		return m.OldDeletedAt(ctx)
+	case provider.FieldDeletedBy:
+		return m.OldDeletedBy(ctx)
 	case provider.FieldCreatedBy:
 		return m.OldCreatedBy(ctx)
 	case provider.FieldUpdatedBy:
@@ -4350,6 +4902,20 @@ func (m *ProviderMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUpdatedAt(v)
+		return nil
+	case provider.FieldDeletedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedAt(v)
+		return nil
+	case provider.FieldDeletedBy:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedBy(v)
 		return nil
 	case provider.FieldCreatedBy:
 		v, ok := value.(string)
@@ -4409,6 +4975,12 @@ func (m *ProviderMutation) AddField(name string, value ent.Value) error {
 // mutation.
 func (m *ProviderMutation) ClearedFields() []string {
 	var fields []string
+	if m.FieldCleared(provider.FieldDeletedAt) {
+		fields = append(fields, provider.FieldDeletedAt)
+	}
+	if m.FieldCleared(provider.FieldDeletedBy) {
+		fields = append(fields, provider.FieldDeletedBy)
+	}
 	if m.FieldCleared(provider.FieldCreatedBy) {
 		fields = append(fields, provider.FieldCreatedBy)
 	}
@@ -4429,6 +5001,12 @@ func (m *ProviderMutation) FieldCleared(name string) bool {
 // error if the field is not defined in the schema.
 func (m *ProviderMutation) ClearField(name string) error {
 	switch name {
+	case provider.FieldDeletedAt:
+		m.ClearDeletedAt()
+		return nil
+	case provider.FieldDeletedBy:
+		m.ClearDeletedBy()
+		return nil
 	case provider.FieldCreatedBy:
 		m.ClearCreatedBy()
 		return nil
@@ -4448,6 +5026,12 @@ func (m *ProviderMutation) ResetField(name string) error {
 		return nil
 	case provider.FieldUpdatedAt:
 		m.ResetUpdatedAt()
+		return nil
+	case provider.FieldDeletedAt:
+		m.ResetDeletedAt()
+		return nil
+	case provider.FieldDeletedBy:
+		m.ResetDeletedBy()
 		return nil
 	case provider.FieldCreatedBy:
 		m.ResetCreatedBy()

--- a/internal/ent/generated/mutation.go
+++ b/internal/ent/generated/mutation.go
@@ -60,6 +60,8 @@ type LoadBalancerMutation struct {
 	updated_at      *time.Time
 	created_by      *string
 	updated_by      *string
+	deleted_at      *time.Time
+	deleted_by      *string
 	name            *string
 	owner_id        *gidx.PrefixedID
 	location_id     *gidx.PrefixedID
@@ -348,6 +350,104 @@ func (m *LoadBalancerMutation) ResetUpdatedBy() {
 	delete(m.clearedFields, loadbalancer.FieldUpdatedBy)
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (m *LoadBalancerMutation) SetDeletedAt(t time.Time) {
+	m.deleted_at = &t
+}
+
+// DeletedAt returns the value of the "deleted_at" field in the mutation.
+func (m *LoadBalancerMutation) DeletedAt() (r time.Time, exists bool) {
+	v := m.deleted_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedAt returns the old "deleted_at" field's value of the LoadBalancer entity.
+// If the LoadBalancer object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *LoadBalancerMutation) OldDeletedAt(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedAt: %w", err)
+	}
+	return oldValue.DeletedAt, nil
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (m *LoadBalancerMutation) ClearDeletedAt() {
+	m.deleted_at = nil
+	m.clearedFields[loadbalancer.FieldDeletedAt] = struct{}{}
+}
+
+// DeletedAtCleared returns if the "deleted_at" field was cleared in this mutation.
+func (m *LoadBalancerMutation) DeletedAtCleared() bool {
+	_, ok := m.clearedFields[loadbalancer.FieldDeletedAt]
+	return ok
+}
+
+// ResetDeletedAt resets all changes to the "deleted_at" field.
+func (m *LoadBalancerMutation) ResetDeletedAt() {
+	m.deleted_at = nil
+	delete(m.clearedFields, loadbalancer.FieldDeletedAt)
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (m *LoadBalancerMutation) SetDeletedBy(s string) {
+	m.deleted_by = &s
+}
+
+// DeletedBy returns the value of the "deleted_by" field in the mutation.
+func (m *LoadBalancerMutation) DeletedBy() (r string, exists bool) {
+	v := m.deleted_by
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldDeletedBy returns the old "deleted_by" field's value of the LoadBalancer entity.
+// If the LoadBalancer object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *LoadBalancerMutation) OldDeletedBy(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldDeletedBy is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldDeletedBy requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldDeletedBy: %w", err)
+	}
+	return oldValue.DeletedBy, nil
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (m *LoadBalancerMutation) ClearDeletedBy() {
+	m.deleted_by = nil
+	m.clearedFields[loadbalancer.FieldDeletedBy] = struct{}{}
+}
+
+// DeletedByCleared returns if the "deleted_by" field was cleared in this mutation.
+func (m *LoadBalancerMutation) DeletedByCleared() bool {
+	_, ok := m.clearedFields[loadbalancer.FieldDeletedBy]
+	return ok
+}
+
+// ResetDeletedBy resets all changes to the "deleted_by" field.
+func (m *LoadBalancerMutation) ResetDeletedBy() {
+	m.deleted_by = nil
+	delete(m.clearedFields, loadbalancer.FieldDeletedBy)
+}
+
 // SetName sets the "name" field.
 func (m *LoadBalancerMutation) SetName(s string) {
 	m.name = &s
@@ -607,7 +707,7 @@ func (m *LoadBalancerMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *LoadBalancerMutation) Fields() []string {
-	fields := make([]string, 0, 8)
+	fields := make([]string, 0, 10)
 	if m.created_at != nil {
 		fields = append(fields, loadbalancer.FieldCreatedAt)
 	}
@@ -619,6 +719,12 @@ func (m *LoadBalancerMutation) Fields() []string {
 	}
 	if m.updated_by != nil {
 		fields = append(fields, loadbalancer.FieldUpdatedBy)
+	}
+	if m.deleted_at != nil {
+		fields = append(fields, loadbalancer.FieldDeletedAt)
+	}
+	if m.deleted_by != nil {
+		fields = append(fields, loadbalancer.FieldDeletedBy)
 	}
 	if m.name != nil {
 		fields = append(fields, loadbalancer.FieldName)
@@ -648,6 +754,10 @@ func (m *LoadBalancerMutation) Field(name string) (ent.Value, bool) {
 		return m.CreatedBy()
 	case loadbalancer.FieldUpdatedBy:
 		return m.UpdatedBy()
+	case loadbalancer.FieldDeletedAt:
+		return m.DeletedAt()
+	case loadbalancer.FieldDeletedBy:
+		return m.DeletedBy()
 	case loadbalancer.FieldName:
 		return m.Name()
 	case loadbalancer.FieldOwnerID:
@@ -673,6 +783,10 @@ func (m *LoadBalancerMutation) OldField(ctx context.Context, name string) (ent.V
 		return m.OldCreatedBy(ctx)
 	case loadbalancer.FieldUpdatedBy:
 		return m.OldUpdatedBy(ctx)
+	case loadbalancer.FieldDeletedAt:
+		return m.OldDeletedAt(ctx)
+	case loadbalancer.FieldDeletedBy:
+		return m.OldDeletedBy(ctx)
 	case loadbalancer.FieldName:
 		return m.OldName(ctx)
 	case loadbalancer.FieldOwnerID:
@@ -717,6 +831,20 @@ func (m *LoadBalancerMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetUpdatedBy(v)
+		return nil
+	case loadbalancer.FieldDeletedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedAt(v)
+		return nil
+	case loadbalancer.FieldDeletedBy:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetDeletedBy(v)
 		return nil
 	case loadbalancer.FieldName:
 		v, ok := value.(string)
@@ -782,6 +910,12 @@ func (m *LoadBalancerMutation) ClearedFields() []string {
 	if m.FieldCleared(loadbalancer.FieldUpdatedBy) {
 		fields = append(fields, loadbalancer.FieldUpdatedBy)
 	}
+	if m.FieldCleared(loadbalancer.FieldDeletedAt) {
+		fields = append(fields, loadbalancer.FieldDeletedAt)
+	}
+	if m.FieldCleared(loadbalancer.FieldDeletedBy) {
+		fields = append(fields, loadbalancer.FieldDeletedBy)
+	}
 	return fields
 }
 
@@ -802,6 +936,12 @@ func (m *LoadBalancerMutation) ClearField(name string) error {
 	case loadbalancer.FieldUpdatedBy:
 		m.ClearUpdatedBy()
 		return nil
+	case loadbalancer.FieldDeletedAt:
+		m.ClearDeletedAt()
+		return nil
+	case loadbalancer.FieldDeletedBy:
+		m.ClearDeletedBy()
+		return nil
 	}
 	return fmt.Errorf("unknown LoadBalancer nullable field %s", name)
 }
@@ -821,6 +961,12 @@ func (m *LoadBalancerMutation) ResetField(name string) error {
 		return nil
 	case loadbalancer.FieldUpdatedBy:
 		m.ResetUpdatedBy()
+		return nil
+	case loadbalancer.FieldDeletedAt:
+		m.ResetDeletedAt()
+		return nil
+	case loadbalancer.FieldDeletedBy:
+		m.ResetDeletedBy()
 		return nil
 	case loadbalancer.FieldName:
 		m.ResetName()

--- a/internal/ent/generated/origin.go
+++ b/internal/ent/generated/origin.go
@@ -37,6 +37,10 @@ type Origin struct {
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	// DeletedAt holds the value of the "deleted_at" field.
+	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	// DeletedBy holds the value of the "deleted_by" field.
+	DeletedBy string `json:"deleted_by,omitempty"`
 	// CreatedBy holds the value of the "created_by" field.
 	CreatedBy string `json:"created_by,omitempty"`
 	// UpdatedBy holds the value of the "updated_by" field.
@@ -94,9 +98,9 @@ func (*Origin) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case origin.FieldWeight, origin.FieldPortNumber:
 			values[i] = new(sql.NullInt64)
-		case origin.FieldCreatedBy, origin.FieldUpdatedBy, origin.FieldName, origin.FieldTarget:
+		case origin.FieldDeletedBy, origin.FieldCreatedBy, origin.FieldUpdatedBy, origin.FieldName, origin.FieldTarget:
 			values[i] = new(sql.NullString)
-		case origin.FieldCreatedAt, origin.FieldUpdatedAt:
+		case origin.FieldCreatedAt, origin.FieldUpdatedAt, origin.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -130,6 +134,18 @@ func (o *Origin) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field updated_at", values[i])
 			} else if value.Valid {
 				o.UpdatedAt = value.Time
+			}
+		case origin.FieldDeletedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_at", values[i])
+			} else if value.Valid {
+				o.DeletedAt = value.Time
+			}
+		case origin.FieldDeletedBy:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_by", values[i])
+			} else if value.Valid {
+				o.DeletedBy = value.String
 			}
 		case origin.FieldCreatedBy:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -225,6 +241,12 @@ func (o *Origin) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("updated_at=")
 	builder.WriteString(o.UpdatedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("deleted_at=")
+	builder.WriteString(o.DeletedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("deleted_by=")
+	builder.WriteString(o.DeletedBy)
 	builder.WriteString(", ")
 	builder.WriteString("created_by=")
 	builder.WriteString(o.CreatedBy)

--- a/internal/ent/generated/origin/origin.go
+++ b/internal/ent/generated/origin/origin.go
@@ -34,6 +34,10 @@ const (
 	FieldCreatedAt = "created_at"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
 	FieldUpdatedAt = "updated_at"
+	// FieldDeletedAt holds the string denoting the deleted_at field in the database.
+	FieldDeletedAt = "deleted_at"
+	// FieldDeletedBy holds the string denoting the deleted_by field in the database.
+	FieldDeletedBy = "deleted_by"
 	// FieldCreatedBy holds the string denoting the created_by field in the database.
 	FieldCreatedBy = "created_by"
 	// FieldUpdatedBy holds the string denoting the updated_by field in the database.
@@ -68,6 +72,8 @@ var Columns = []string{
 	FieldID,
 	FieldCreatedAt,
 	FieldUpdatedAt,
+	FieldDeletedAt,
+	FieldDeletedBy,
 	FieldCreatedBy,
 	FieldUpdatedBy,
 	FieldName,
@@ -94,7 +100,8 @@ func ValidColumn(column string) bool {
 //
 //	import _ "go.infratographer.com/load-balancer-api/internal/ent/generated/runtime"
 var (
-	Hooks [1]ent.Hook
+	Hooks        [2]ent.Hook
+	Interceptors [1]ent.Interceptor
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -133,6 +140,16 @@ func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByUpdatedAt orders the results by the updated_at field.
 func ByUpdatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUpdatedAt, opts...).ToFunc()
+}
+
+// ByDeletedAt orders the results by the deleted_at field.
+func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
+}
+
+// ByDeletedBy orders the results by the deleted_by field.
+func ByDeletedBy(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedBy, opts...).ToFunc()
 }
 
 // ByCreatedBy orders the results by the created_by field.

--- a/internal/ent/generated/origin/where.go
+++ b/internal/ent/generated/origin/where.go
@@ -80,6 +80,16 @@ func UpdatedAt(v time.Time) predicate.Origin {
 	return predicate.Origin(sql.FieldEQ(FieldUpdatedAt, v))
 }
 
+// DeletedAt applies equality check predicate on the "deleted_at" field. It's identical to DeletedAtEQ.
+func DeletedAt(v time.Time) predicate.Origin {
+	return predicate.Origin(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedBy applies equality check predicate on the "deleted_by" field. It's identical to DeletedByEQ.
+func DeletedBy(v string) predicate.Origin {
+	return predicate.Origin(sql.FieldEQ(FieldDeletedBy, v))
+}
+
 // CreatedBy applies equality check predicate on the "created_by" field. It's identical to CreatedByEQ.
 func CreatedBy(v string) predicate.Origin {
 	return predicate.Origin(sql.FieldEQ(FieldCreatedBy, v))
@@ -198,6 +208,131 @@ func UpdatedAtLT(v time.Time) predicate.Origin {
 // UpdatedAtLTE applies the LTE predicate on the "updated_at" field.
 func UpdatedAtLTE(v time.Time) predicate.Origin {
 	return predicate.Origin(sql.FieldLTE(FieldUpdatedAt, v))
+}
+
+// DeletedAtEQ applies the EQ predicate on the "deleted_at" field.
+func DeletedAtEQ(v time.Time) predicate.Origin {
+	return predicate.Origin(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtNEQ applies the NEQ predicate on the "deleted_at" field.
+func DeletedAtNEQ(v time.Time) predicate.Origin {
+	return predicate.Origin(sql.FieldNEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtIn applies the In predicate on the "deleted_at" field.
+func DeletedAtIn(vs ...time.Time) predicate.Origin {
+	return predicate.Origin(sql.FieldIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtNotIn applies the NotIn predicate on the "deleted_at" field.
+func DeletedAtNotIn(vs ...time.Time) predicate.Origin {
+	return predicate.Origin(sql.FieldNotIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtGT applies the GT predicate on the "deleted_at" field.
+func DeletedAtGT(v time.Time) predicate.Origin {
+	return predicate.Origin(sql.FieldGT(FieldDeletedAt, v))
+}
+
+// DeletedAtGTE applies the GTE predicate on the "deleted_at" field.
+func DeletedAtGTE(v time.Time) predicate.Origin {
+	return predicate.Origin(sql.FieldGTE(FieldDeletedAt, v))
+}
+
+// DeletedAtLT applies the LT predicate on the "deleted_at" field.
+func DeletedAtLT(v time.Time) predicate.Origin {
+	return predicate.Origin(sql.FieldLT(FieldDeletedAt, v))
+}
+
+// DeletedAtLTE applies the LTE predicate on the "deleted_at" field.
+func DeletedAtLTE(v time.Time) predicate.Origin {
+	return predicate.Origin(sql.FieldLTE(FieldDeletedAt, v))
+}
+
+// DeletedAtIsNil applies the IsNil predicate on the "deleted_at" field.
+func DeletedAtIsNil() predicate.Origin {
+	return predicate.Origin(sql.FieldIsNull(FieldDeletedAt))
+}
+
+// DeletedAtNotNil applies the NotNil predicate on the "deleted_at" field.
+func DeletedAtNotNil() predicate.Origin {
+	return predicate.Origin(sql.FieldNotNull(FieldDeletedAt))
+}
+
+// DeletedByEQ applies the EQ predicate on the "deleted_by" field.
+func DeletedByEQ(v string) predicate.Origin {
+	return predicate.Origin(sql.FieldEQ(FieldDeletedBy, v))
+}
+
+// DeletedByNEQ applies the NEQ predicate on the "deleted_by" field.
+func DeletedByNEQ(v string) predicate.Origin {
+	return predicate.Origin(sql.FieldNEQ(FieldDeletedBy, v))
+}
+
+// DeletedByIn applies the In predicate on the "deleted_by" field.
+func DeletedByIn(vs ...string) predicate.Origin {
+	return predicate.Origin(sql.FieldIn(FieldDeletedBy, vs...))
+}
+
+// DeletedByNotIn applies the NotIn predicate on the "deleted_by" field.
+func DeletedByNotIn(vs ...string) predicate.Origin {
+	return predicate.Origin(sql.FieldNotIn(FieldDeletedBy, vs...))
+}
+
+// DeletedByGT applies the GT predicate on the "deleted_by" field.
+func DeletedByGT(v string) predicate.Origin {
+	return predicate.Origin(sql.FieldGT(FieldDeletedBy, v))
+}
+
+// DeletedByGTE applies the GTE predicate on the "deleted_by" field.
+func DeletedByGTE(v string) predicate.Origin {
+	return predicate.Origin(sql.FieldGTE(FieldDeletedBy, v))
+}
+
+// DeletedByLT applies the LT predicate on the "deleted_by" field.
+func DeletedByLT(v string) predicate.Origin {
+	return predicate.Origin(sql.FieldLT(FieldDeletedBy, v))
+}
+
+// DeletedByLTE applies the LTE predicate on the "deleted_by" field.
+func DeletedByLTE(v string) predicate.Origin {
+	return predicate.Origin(sql.FieldLTE(FieldDeletedBy, v))
+}
+
+// DeletedByContains applies the Contains predicate on the "deleted_by" field.
+func DeletedByContains(v string) predicate.Origin {
+	return predicate.Origin(sql.FieldContains(FieldDeletedBy, v))
+}
+
+// DeletedByHasPrefix applies the HasPrefix predicate on the "deleted_by" field.
+func DeletedByHasPrefix(v string) predicate.Origin {
+	return predicate.Origin(sql.FieldHasPrefix(FieldDeletedBy, v))
+}
+
+// DeletedByHasSuffix applies the HasSuffix predicate on the "deleted_by" field.
+func DeletedByHasSuffix(v string) predicate.Origin {
+	return predicate.Origin(sql.FieldHasSuffix(FieldDeletedBy, v))
+}
+
+// DeletedByIsNil applies the IsNil predicate on the "deleted_by" field.
+func DeletedByIsNil() predicate.Origin {
+	return predicate.Origin(sql.FieldIsNull(FieldDeletedBy))
+}
+
+// DeletedByNotNil applies the NotNil predicate on the "deleted_by" field.
+func DeletedByNotNil() predicate.Origin {
+	return predicate.Origin(sql.FieldNotNull(FieldDeletedBy))
+}
+
+// DeletedByEqualFold applies the EqualFold predicate on the "deleted_by" field.
+func DeletedByEqualFold(v string) predicate.Origin {
+	return predicate.Origin(sql.FieldEqualFold(FieldDeletedBy, v))
+}
+
+// DeletedByContainsFold applies the ContainsFold predicate on the "deleted_by" field.
+func DeletedByContainsFold(v string) predicate.Origin {
+	return predicate.Origin(sql.FieldContainsFold(FieldDeletedBy, v))
 }
 
 // CreatedByEQ applies the EQ predicate on the "created_by" field.

--- a/internal/ent/generated/origin_create.go
+++ b/internal/ent/generated/origin_create.go
@@ -64,6 +64,34 @@ func (oc *OriginCreate) SetNillableUpdatedAt(t *time.Time) *OriginCreate {
 	return oc
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (oc *OriginCreate) SetDeletedAt(t time.Time) *OriginCreate {
+	oc.mutation.SetDeletedAt(t)
+	return oc
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (oc *OriginCreate) SetNillableDeletedAt(t *time.Time) *OriginCreate {
+	if t != nil {
+		oc.SetDeletedAt(*t)
+	}
+	return oc
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (oc *OriginCreate) SetDeletedBy(s string) *OriginCreate {
+	oc.mutation.SetDeletedBy(s)
+	return oc
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (oc *OriginCreate) SetNillableDeletedBy(s *string) *OriginCreate {
+	if s != nil {
+		oc.SetDeletedBy(*s)
+	}
+	return oc
+}
+
 // SetCreatedBy sets the "created_by" field.
 func (oc *OriginCreate) SetCreatedBy(s string) *OriginCreate {
 	oc.mutation.SetCreatedBy(s)
@@ -323,6 +351,14 @@ func (oc *OriginCreate) createSpec() (*Origin, *sqlgraph.CreateSpec) {
 	if value, ok := oc.mutation.UpdatedAt(); ok {
 		_spec.SetField(origin.FieldUpdatedAt, field.TypeTime, value)
 		_node.UpdatedAt = value
+	}
+	if value, ok := oc.mutation.DeletedAt(); ok {
+		_spec.SetField(origin.FieldDeletedAt, field.TypeTime, value)
+		_node.DeletedAt = value
+	}
+	if value, ok := oc.mutation.DeletedBy(); ok {
+		_spec.SetField(origin.FieldDeletedBy, field.TypeString, value)
+		_node.DeletedBy = value
 	}
 	if value, ok := oc.mutation.CreatedBy(); ok {
 		_spec.SetField(origin.FieldCreatedBy, field.TypeString, value)

--- a/internal/ent/generated/origin_update.go
+++ b/internal/ent/generated/origin_update.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -38,6 +39,46 @@ type OriginUpdate struct {
 // Where appends a list predicates to the OriginUpdate builder.
 func (ou *OriginUpdate) Where(ps ...predicate.Origin) *OriginUpdate {
 	ou.mutation.Where(ps...)
+	return ou
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (ou *OriginUpdate) SetDeletedAt(t time.Time) *OriginUpdate {
+	ou.mutation.SetDeletedAt(t)
+	return ou
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (ou *OriginUpdate) SetNillableDeletedAt(t *time.Time) *OriginUpdate {
+	if t != nil {
+		ou.SetDeletedAt(*t)
+	}
+	return ou
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (ou *OriginUpdate) ClearDeletedAt() *OriginUpdate {
+	ou.mutation.ClearDeletedAt()
+	return ou
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (ou *OriginUpdate) SetDeletedBy(s string) *OriginUpdate {
+	ou.mutation.SetDeletedBy(s)
+	return ou
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (ou *OriginUpdate) SetNillableDeletedBy(s *string) *OriginUpdate {
+	if s != nil {
+		ou.SetDeletedBy(*s)
+	}
+	return ou
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (ou *OriginUpdate) ClearDeletedBy() *OriginUpdate {
+	ou.mutation.ClearDeletedBy()
 	return ou
 }
 
@@ -206,6 +247,18 @@ func (ou *OriginUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if value, ok := ou.mutation.UpdatedAt(); ok {
 		_spec.SetField(origin.FieldUpdatedAt, field.TypeTime, value)
 	}
+	if value, ok := ou.mutation.DeletedAt(); ok {
+		_spec.SetField(origin.FieldDeletedAt, field.TypeTime, value)
+	}
+	if ou.mutation.DeletedAtCleared() {
+		_spec.ClearField(origin.FieldDeletedAt, field.TypeTime)
+	}
+	if value, ok := ou.mutation.DeletedBy(); ok {
+		_spec.SetField(origin.FieldDeletedBy, field.TypeString, value)
+	}
+	if ou.mutation.DeletedByCleared() {
+		_spec.ClearField(origin.FieldDeletedBy, field.TypeString)
+	}
 	if ou.mutation.CreatedByCleared() {
 		_spec.ClearField(origin.FieldCreatedBy, field.TypeString)
 	}
@@ -254,6 +307,46 @@ type OriginUpdateOne struct {
 	fields   []string
 	hooks    []Hook
 	mutation *OriginMutation
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (ouo *OriginUpdateOne) SetDeletedAt(t time.Time) *OriginUpdateOne {
+	ouo.mutation.SetDeletedAt(t)
+	return ouo
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (ouo *OriginUpdateOne) SetNillableDeletedAt(t *time.Time) *OriginUpdateOne {
+	if t != nil {
+		ouo.SetDeletedAt(*t)
+	}
+	return ouo
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (ouo *OriginUpdateOne) ClearDeletedAt() *OriginUpdateOne {
+	ouo.mutation.ClearDeletedAt()
+	return ouo
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (ouo *OriginUpdateOne) SetDeletedBy(s string) *OriginUpdateOne {
+	ouo.mutation.SetDeletedBy(s)
+	return ouo
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (ouo *OriginUpdateOne) SetNillableDeletedBy(s *string) *OriginUpdateOne {
+	if s != nil {
+		ouo.SetDeletedBy(*s)
+	}
+	return ouo
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (ouo *OriginUpdateOne) ClearDeletedBy() *OriginUpdateOne {
+	ouo.mutation.ClearDeletedBy()
+	return ouo
 }
 
 // SetUpdatedBy sets the "updated_by" field.
@@ -450,6 +543,18 @@ func (ouo *OriginUpdateOne) sqlSave(ctx context.Context) (_node *Origin, err err
 	}
 	if value, ok := ouo.mutation.UpdatedAt(); ok {
 		_spec.SetField(origin.FieldUpdatedAt, field.TypeTime, value)
+	}
+	if value, ok := ouo.mutation.DeletedAt(); ok {
+		_spec.SetField(origin.FieldDeletedAt, field.TypeTime, value)
+	}
+	if ouo.mutation.DeletedAtCleared() {
+		_spec.ClearField(origin.FieldDeletedAt, field.TypeTime)
+	}
+	if value, ok := ouo.mutation.DeletedBy(); ok {
+		_spec.SetField(origin.FieldDeletedBy, field.TypeString, value)
+	}
+	if ouo.mutation.DeletedByCleared() {
+		_spec.ClearField(origin.FieldDeletedBy, field.TypeString)
 	}
 	if ouo.mutation.CreatedByCleared() {
 		_spec.ClearField(origin.FieldCreatedBy, field.TypeString)

--- a/internal/ent/generated/pool.go
+++ b/internal/ent/generated/pool.go
@@ -40,6 +40,10 @@ type Pool struct {
 	CreatedBy string `json:"created_by,omitempty"`
 	// UpdatedBy holds the value of the "updated_by" field.
 	UpdatedBy string `json:"updated_by,omitempty"`
+	// DeletedAt holds the value of the "deleted_at" field.
+	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	// DeletedBy holds the value of the "deleted_by" field.
+	DeletedBy string `json:"deleted_by,omitempty"`
 	// Name holds the value of the "name" field.
 	Name string `json:"name,omitempty"`
 	// Protocol holds the value of the "protocol" field.
@@ -93,9 +97,9 @@ func (*Pool) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case pool.FieldID, pool.FieldOwnerID:
 			values[i] = new(gidx.PrefixedID)
-		case pool.FieldCreatedBy, pool.FieldUpdatedBy, pool.FieldName, pool.FieldProtocol:
+		case pool.FieldCreatedBy, pool.FieldUpdatedBy, pool.FieldDeletedBy, pool.FieldName, pool.FieldProtocol:
 			values[i] = new(sql.NullString)
-		case pool.FieldCreatedAt, pool.FieldUpdatedAt:
+		case pool.FieldCreatedAt, pool.FieldUpdatedAt, pool.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -141,6 +145,18 @@ func (po *Pool) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field updated_by", values[i])
 			} else if value.Valid {
 				po.UpdatedBy = value.String
+			}
+		case pool.FieldDeletedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_at", values[i])
+			} else if value.Valid {
+				po.DeletedAt = value.Time
+			}
+		case pool.FieldDeletedBy:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_by", values[i])
+			} else if value.Valid {
+				po.DeletedBy = value.String
 			}
 		case pool.FieldName:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -217,6 +233,12 @@ func (po *Pool) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("updated_by=")
 	builder.WriteString(po.UpdatedBy)
+	builder.WriteString(", ")
+	builder.WriteString("deleted_at=")
+	builder.WriteString(po.DeletedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("deleted_by=")
+	builder.WriteString(po.DeletedBy)
 	builder.WriteString(", ")
 	builder.WriteString("name=")
 	builder.WriteString(po.Name)

--- a/internal/ent/generated/pool/pool.go
+++ b/internal/ent/generated/pool/pool.go
@@ -41,6 +41,10 @@ const (
 	FieldCreatedBy = "created_by"
 	// FieldUpdatedBy holds the string denoting the updated_by field in the database.
 	FieldUpdatedBy = "updated_by"
+	// FieldDeletedAt holds the string denoting the deleted_at field in the database.
+	FieldDeletedAt = "deleted_at"
+	// FieldDeletedBy holds the string denoting the deleted_by field in the database.
+	FieldDeletedBy = "deleted_by"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
 	// FieldProtocol holds the string denoting the protocol field in the database.
@@ -74,6 +78,8 @@ var Columns = []string{
 	FieldUpdatedAt,
 	FieldCreatedBy,
 	FieldUpdatedBy,
+	FieldDeletedAt,
+	FieldDeletedBy,
 	FieldName,
 	FieldProtocol,
 	FieldOwnerID,
@@ -101,7 +107,8 @@ func ValidColumn(column string) bool {
 //
 //	import _ "go.infratographer.com/load-balancer-api/internal/ent/generated/runtime"
 var (
-	Hooks [1]ent.Hook
+	Hooks        [2]ent.Hook
+	Interceptors [1]ent.Interceptor
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -165,6 +172,16 @@ func ByCreatedBy(opts ...sql.OrderTermOption) OrderOption {
 // ByUpdatedBy orders the results by the updated_by field.
 func ByUpdatedBy(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUpdatedBy, opts...).ToFunc()
+}
+
+// ByDeletedAt orders the results by the deleted_at field.
+func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
+}
+
+// ByDeletedBy orders the results by the deleted_by field.
+func ByDeletedBy(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedBy, opts...).ToFunc()
 }
 
 // ByName orders the results by the name field.

--- a/internal/ent/generated/pool/where.go
+++ b/internal/ent/generated/pool/where.go
@@ -90,6 +90,16 @@ func UpdatedBy(v string) predicate.Pool {
 	return predicate.Pool(sql.FieldEQ(FieldUpdatedBy, v))
 }
 
+// DeletedAt applies equality check predicate on the "deleted_at" field. It's identical to DeletedAtEQ.
+func DeletedAt(v time.Time) predicate.Pool {
+	return predicate.Pool(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedBy applies equality check predicate on the "deleted_by" field. It's identical to DeletedByEQ.
+func DeletedBy(v string) predicate.Pool {
+	return predicate.Pool(sql.FieldEQ(FieldDeletedBy, v))
+}
+
 // Name applies equality check predicate on the "name" field. It's identical to NameEQ.
 func Name(v string) predicate.Pool {
 	return predicate.Pool(sql.FieldEQ(FieldName, v))
@@ -328,6 +338,131 @@ func UpdatedByEqualFold(v string) predicate.Pool {
 // UpdatedByContainsFold applies the ContainsFold predicate on the "updated_by" field.
 func UpdatedByContainsFold(v string) predicate.Pool {
 	return predicate.Pool(sql.FieldContainsFold(FieldUpdatedBy, v))
+}
+
+// DeletedAtEQ applies the EQ predicate on the "deleted_at" field.
+func DeletedAtEQ(v time.Time) predicate.Pool {
+	return predicate.Pool(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtNEQ applies the NEQ predicate on the "deleted_at" field.
+func DeletedAtNEQ(v time.Time) predicate.Pool {
+	return predicate.Pool(sql.FieldNEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtIn applies the In predicate on the "deleted_at" field.
+func DeletedAtIn(vs ...time.Time) predicate.Pool {
+	return predicate.Pool(sql.FieldIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtNotIn applies the NotIn predicate on the "deleted_at" field.
+func DeletedAtNotIn(vs ...time.Time) predicate.Pool {
+	return predicate.Pool(sql.FieldNotIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtGT applies the GT predicate on the "deleted_at" field.
+func DeletedAtGT(v time.Time) predicate.Pool {
+	return predicate.Pool(sql.FieldGT(FieldDeletedAt, v))
+}
+
+// DeletedAtGTE applies the GTE predicate on the "deleted_at" field.
+func DeletedAtGTE(v time.Time) predicate.Pool {
+	return predicate.Pool(sql.FieldGTE(FieldDeletedAt, v))
+}
+
+// DeletedAtLT applies the LT predicate on the "deleted_at" field.
+func DeletedAtLT(v time.Time) predicate.Pool {
+	return predicate.Pool(sql.FieldLT(FieldDeletedAt, v))
+}
+
+// DeletedAtLTE applies the LTE predicate on the "deleted_at" field.
+func DeletedAtLTE(v time.Time) predicate.Pool {
+	return predicate.Pool(sql.FieldLTE(FieldDeletedAt, v))
+}
+
+// DeletedAtIsNil applies the IsNil predicate on the "deleted_at" field.
+func DeletedAtIsNil() predicate.Pool {
+	return predicate.Pool(sql.FieldIsNull(FieldDeletedAt))
+}
+
+// DeletedAtNotNil applies the NotNil predicate on the "deleted_at" field.
+func DeletedAtNotNil() predicate.Pool {
+	return predicate.Pool(sql.FieldNotNull(FieldDeletedAt))
+}
+
+// DeletedByEQ applies the EQ predicate on the "deleted_by" field.
+func DeletedByEQ(v string) predicate.Pool {
+	return predicate.Pool(sql.FieldEQ(FieldDeletedBy, v))
+}
+
+// DeletedByNEQ applies the NEQ predicate on the "deleted_by" field.
+func DeletedByNEQ(v string) predicate.Pool {
+	return predicate.Pool(sql.FieldNEQ(FieldDeletedBy, v))
+}
+
+// DeletedByIn applies the In predicate on the "deleted_by" field.
+func DeletedByIn(vs ...string) predicate.Pool {
+	return predicate.Pool(sql.FieldIn(FieldDeletedBy, vs...))
+}
+
+// DeletedByNotIn applies the NotIn predicate on the "deleted_by" field.
+func DeletedByNotIn(vs ...string) predicate.Pool {
+	return predicate.Pool(sql.FieldNotIn(FieldDeletedBy, vs...))
+}
+
+// DeletedByGT applies the GT predicate on the "deleted_by" field.
+func DeletedByGT(v string) predicate.Pool {
+	return predicate.Pool(sql.FieldGT(FieldDeletedBy, v))
+}
+
+// DeletedByGTE applies the GTE predicate on the "deleted_by" field.
+func DeletedByGTE(v string) predicate.Pool {
+	return predicate.Pool(sql.FieldGTE(FieldDeletedBy, v))
+}
+
+// DeletedByLT applies the LT predicate on the "deleted_by" field.
+func DeletedByLT(v string) predicate.Pool {
+	return predicate.Pool(sql.FieldLT(FieldDeletedBy, v))
+}
+
+// DeletedByLTE applies the LTE predicate on the "deleted_by" field.
+func DeletedByLTE(v string) predicate.Pool {
+	return predicate.Pool(sql.FieldLTE(FieldDeletedBy, v))
+}
+
+// DeletedByContains applies the Contains predicate on the "deleted_by" field.
+func DeletedByContains(v string) predicate.Pool {
+	return predicate.Pool(sql.FieldContains(FieldDeletedBy, v))
+}
+
+// DeletedByHasPrefix applies the HasPrefix predicate on the "deleted_by" field.
+func DeletedByHasPrefix(v string) predicate.Pool {
+	return predicate.Pool(sql.FieldHasPrefix(FieldDeletedBy, v))
+}
+
+// DeletedByHasSuffix applies the HasSuffix predicate on the "deleted_by" field.
+func DeletedByHasSuffix(v string) predicate.Pool {
+	return predicate.Pool(sql.FieldHasSuffix(FieldDeletedBy, v))
+}
+
+// DeletedByIsNil applies the IsNil predicate on the "deleted_by" field.
+func DeletedByIsNil() predicate.Pool {
+	return predicate.Pool(sql.FieldIsNull(FieldDeletedBy))
+}
+
+// DeletedByNotNil applies the NotNil predicate on the "deleted_by" field.
+func DeletedByNotNil() predicate.Pool {
+	return predicate.Pool(sql.FieldNotNull(FieldDeletedBy))
+}
+
+// DeletedByEqualFold applies the EqualFold predicate on the "deleted_by" field.
+func DeletedByEqualFold(v string) predicate.Pool {
+	return predicate.Pool(sql.FieldEqualFold(FieldDeletedBy, v))
+}
+
+// DeletedByContainsFold applies the ContainsFold predicate on the "deleted_by" field.
+func DeletedByContainsFold(v string) predicate.Pool {
+	return predicate.Pool(sql.FieldContainsFold(FieldDeletedBy, v))
 }
 
 // NameEQ applies the EQ predicate on the "name" field.

--- a/internal/ent/generated/pool_create.go
+++ b/internal/ent/generated/pool_create.go
@@ -93,6 +93,34 @@ func (pc *PoolCreate) SetNillableUpdatedBy(s *string) *PoolCreate {
 	return pc
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (pc *PoolCreate) SetDeletedAt(t time.Time) *PoolCreate {
+	pc.mutation.SetDeletedAt(t)
+	return pc
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (pc *PoolCreate) SetNillableDeletedAt(t *time.Time) *PoolCreate {
+	if t != nil {
+		pc.SetDeletedAt(*t)
+	}
+	return pc
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (pc *PoolCreate) SetDeletedBy(s string) *PoolCreate {
+	pc.mutation.SetDeletedBy(s)
+	return pc
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (pc *PoolCreate) SetNillableDeletedBy(s *string) *PoolCreate {
+	if s != nil {
+		pc.SetDeletedBy(*s)
+	}
+	return pc
+}
+
 // SetName sets the "name" field.
 func (pc *PoolCreate) SetName(s string) *PoolCreate {
 	pc.mutation.SetName(s)
@@ -298,6 +326,14 @@ func (pc *PoolCreate) createSpec() (*Pool, *sqlgraph.CreateSpec) {
 	if value, ok := pc.mutation.UpdatedBy(); ok {
 		_spec.SetField(pool.FieldUpdatedBy, field.TypeString, value)
 		_node.UpdatedBy = value
+	}
+	if value, ok := pc.mutation.DeletedAt(); ok {
+		_spec.SetField(pool.FieldDeletedAt, field.TypeTime, value)
+		_node.DeletedAt = value
+	}
+	if value, ok := pc.mutation.DeletedBy(); ok {
+		_spec.SetField(pool.FieldDeletedBy, field.TypeString, value)
+		_node.DeletedBy = value
 	}
 	if value, ok := pc.mutation.Name(); ok {
 		_spec.SetField(pool.FieldName, field.TypeString, value)

--- a/internal/ent/generated/pool_update.go
+++ b/internal/ent/generated/pool_update.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -61,6 +62,46 @@ func (pu *PoolUpdate) SetNillableUpdatedBy(s *string) *PoolUpdate {
 // ClearUpdatedBy clears the value of the "updated_by" field.
 func (pu *PoolUpdate) ClearUpdatedBy() *PoolUpdate {
 	pu.mutation.ClearUpdatedBy()
+	return pu
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (pu *PoolUpdate) SetDeletedAt(t time.Time) *PoolUpdate {
+	pu.mutation.SetDeletedAt(t)
+	return pu
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (pu *PoolUpdate) SetNillableDeletedAt(t *time.Time) *PoolUpdate {
+	if t != nil {
+		pu.SetDeletedAt(*t)
+	}
+	return pu
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (pu *PoolUpdate) ClearDeletedAt() *PoolUpdate {
+	pu.mutation.ClearDeletedAt()
+	return pu
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (pu *PoolUpdate) SetDeletedBy(s string) *PoolUpdate {
+	pu.mutation.SetDeletedBy(s)
+	return pu
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (pu *PoolUpdate) SetNillableDeletedBy(s *string) *PoolUpdate {
+	if s != nil {
+		pu.SetDeletedBy(*s)
+	}
+	return pu
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (pu *PoolUpdate) ClearDeletedBy() *PoolUpdate {
+	pu.mutation.ClearDeletedBy()
 	return pu
 }
 
@@ -234,6 +275,18 @@ func (pu *PoolUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if pu.mutation.UpdatedByCleared() {
 		_spec.ClearField(pool.FieldUpdatedBy, field.TypeString)
 	}
+	if value, ok := pu.mutation.DeletedAt(); ok {
+		_spec.SetField(pool.FieldDeletedAt, field.TypeTime, value)
+	}
+	if pu.mutation.DeletedAtCleared() {
+		_spec.ClearField(pool.FieldDeletedAt, field.TypeTime)
+	}
+	if value, ok := pu.mutation.DeletedBy(); ok {
+		_spec.SetField(pool.FieldDeletedBy, field.TypeString, value)
+	}
+	if pu.mutation.DeletedByCleared() {
+		_spec.ClearField(pool.FieldDeletedBy, field.TypeString)
+	}
 	if value, ok := pu.mutation.Name(); ok {
 		_spec.SetField(pool.FieldName, field.TypeString, value)
 	}
@@ -367,6 +420,46 @@ func (puo *PoolUpdateOne) SetNillableUpdatedBy(s *string) *PoolUpdateOne {
 // ClearUpdatedBy clears the value of the "updated_by" field.
 func (puo *PoolUpdateOne) ClearUpdatedBy() *PoolUpdateOne {
 	puo.mutation.ClearUpdatedBy()
+	return puo
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (puo *PoolUpdateOne) SetDeletedAt(t time.Time) *PoolUpdateOne {
+	puo.mutation.SetDeletedAt(t)
+	return puo
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (puo *PoolUpdateOne) SetNillableDeletedAt(t *time.Time) *PoolUpdateOne {
+	if t != nil {
+		puo.SetDeletedAt(*t)
+	}
+	return puo
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (puo *PoolUpdateOne) ClearDeletedAt() *PoolUpdateOne {
+	puo.mutation.ClearDeletedAt()
+	return puo
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (puo *PoolUpdateOne) SetDeletedBy(s string) *PoolUpdateOne {
+	puo.mutation.SetDeletedBy(s)
+	return puo
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (puo *PoolUpdateOne) SetNillableDeletedBy(s *string) *PoolUpdateOne {
+	if s != nil {
+		puo.SetDeletedBy(*s)
+	}
+	return puo
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (puo *PoolUpdateOne) ClearDeletedBy() *PoolUpdateOne {
+	puo.mutation.ClearDeletedBy()
 	return puo
 }
 
@@ -569,6 +662,18 @@ func (puo *PoolUpdateOne) sqlSave(ctx context.Context) (_node *Pool, err error) 
 	}
 	if puo.mutation.UpdatedByCleared() {
 		_spec.ClearField(pool.FieldUpdatedBy, field.TypeString)
+	}
+	if value, ok := puo.mutation.DeletedAt(); ok {
+		_spec.SetField(pool.FieldDeletedAt, field.TypeTime, value)
+	}
+	if puo.mutation.DeletedAtCleared() {
+		_spec.ClearField(pool.FieldDeletedAt, field.TypeTime)
+	}
+	if value, ok := puo.mutation.DeletedBy(); ok {
+		_spec.SetField(pool.FieldDeletedBy, field.TypeString, value)
+	}
+	if puo.mutation.DeletedByCleared() {
+		_spec.ClearField(pool.FieldDeletedBy, field.TypeString)
 	}
 	if value, ok := puo.mutation.Name(); ok {
 		_spec.SetField(pool.FieldName, field.TypeString, value)

--- a/internal/ent/generated/port.go
+++ b/internal/ent/generated/port.go
@@ -37,6 +37,10 @@ type Port struct {
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	// DeletedAt holds the value of the "deleted_at" field.
+	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	// DeletedBy holds the value of the "deleted_by" field.
+	DeletedBy string `json:"deleted_by,omitempty"`
 	// CreatedBy holds the value of the "created_by" field.
 	CreatedBy string `json:"created_by,omitempty"`
 	// UpdatedBy holds the value of the "updated_by" field.
@@ -99,9 +103,9 @@ func (*Port) scanValues(columns []string) ([]any, error) {
 			values[i] = new(gidx.PrefixedID)
 		case port.FieldNumber:
 			values[i] = new(sql.NullInt64)
-		case port.FieldCreatedBy, port.FieldUpdatedBy, port.FieldName:
+		case port.FieldDeletedBy, port.FieldCreatedBy, port.FieldUpdatedBy, port.FieldName:
 			values[i] = new(sql.NullString)
-		case port.FieldCreatedAt, port.FieldUpdatedAt:
+		case port.FieldCreatedAt, port.FieldUpdatedAt, port.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -135,6 +139,18 @@ func (po *Port) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field updated_at", values[i])
 			} else if value.Valid {
 				po.UpdatedAt = value.Time
+			}
+		case port.FieldDeletedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_at", values[i])
+			} else if value.Valid {
+				po.DeletedAt = value.Time
+			}
+		case port.FieldDeletedBy:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_by", values[i])
+			} else if value.Valid {
+				po.DeletedBy = value.String
 			}
 		case port.FieldCreatedBy:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -217,6 +233,12 @@ func (po *Port) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("updated_at=")
 	builder.WriteString(po.UpdatedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("deleted_at=")
+	builder.WriteString(po.DeletedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("deleted_by=")
+	builder.WriteString(po.DeletedBy)
 	builder.WriteString(", ")
 	builder.WriteString("created_by=")
 	builder.WriteString(po.CreatedBy)

--- a/internal/ent/generated/port/port.go
+++ b/internal/ent/generated/port/port.go
@@ -34,6 +34,10 @@ const (
 	FieldCreatedAt = "created_at"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
 	FieldUpdatedAt = "updated_at"
+	// FieldDeletedAt holds the string denoting the deleted_at field in the database.
+	FieldDeletedAt = "deleted_at"
+	// FieldDeletedBy holds the string denoting the deleted_by field in the database.
+	FieldDeletedBy = "deleted_by"
 	// FieldCreatedBy holds the string denoting the created_by field in the database.
 	FieldCreatedBy = "created_by"
 	// FieldUpdatedBy holds the string denoting the updated_by field in the database.
@@ -69,6 +73,8 @@ var Columns = []string{
 	FieldID,
 	FieldCreatedAt,
 	FieldUpdatedAt,
+	FieldDeletedAt,
+	FieldDeletedBy,
 	FieldCreatedBy,
 	FieldUpdatedBy,
 	FieldNumber,
@@ -98,7 +104,8 @@ func ValidColumn(column string) bool {
 //
 //	import _ "go.infratographer.com/load-balancer-api/internal/ent/generated/runtime"
 var (
-	Hooks [1]ent.Hook
+	Hooks        [2]ent.Hook
+	Interceptors [1]ent.Interceptor
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -129,6 +136,16 @@ func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByUpdatedAt orders the results by the updated_at field.
 func ByUpdatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUpdatedAt, opts...).ToFunc()
+}
+
+// ByDeletedAt orders the results by the deleted_at field.
+func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
+}
+
+// ByDeletedBy orders the results by the deleted_by field.
+func ByDeletedBy(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedBy, opts...).ToFunc()
 }
 
 // ByCreatedBy orders the results by the created_by field.

--- a/internal/ent/generated/port/where.go
+++ b/internal/ent/generated/port/where.go
@@ -80,6 +80,16 @@ func UpdatedAt(v time.Time) predicate.Port {
 	return predicate.Port(sql.FieldEQ(FieldUpdatedAt, v))
 }
 
+// DeletedAt applies equality check predicate on the "deleted_at" field. It's identical to DeletedAtEQ.
+func DeletedAt(v time.Time) predicate.Port {
+	return predicate.Port(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedBy applies equality check predicate on the "deleted_by" field. It's identical to DeletedByEQ.
+func DeletedBy(v string) predicate.Port {
+	return predicate.Port(sql.FieldEQ(FieldDeletedBy, v))
+}
+
 // CreatedBy applies equality check predicate on the "created_by" field. It's identical to CreatedByEQ.
 func CreatedBy(v string) predicate.Port {
 	return predicate.Port(sql.FieldEQ(FieldCreatedBy, v))
@@ -183,6 +193,131 @@ func UpdatedAtLT(v time.Time) predicate.Port {
 // UpdatedAtLTE applies the LTE predicate on the "updated_at" field.
 func UpdatedAtLTE(v time.Time) predicate.Port {
 	return predicate.Port(sql.FieldLTE(FieldUpdatedAt, v))
+}
+
+// DeletedAtEQ applies the EQ predicate on the "deleted_at" field.
+func DeletedAtEQ(v time.Time) predicate.Port {
+	return predicate.Port(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtNEQ applies the NEQ predicate on the "deleted_at" field.
+func DeletedAtNEQ(v time.Time) predicate.Port {
+	return predicate.Port(sql.FieldNEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtIn applies the In predicate on the "deleted_at" field.
+func DeletedAtIn(vs ...time.Time) predicate.Port {
+	return predicate.Port(sql.FieldIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtNotIn applies the NotIn predicate on the "deleted_at" field.
+func DeletedAtNotIn(vs ...time.Time) predicate.Port {
+	return predicate.Port(sql.FieldNotIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtGT applies the GT predicate on the "deleted_at" field.
+func DeletedAtGT(v time.Time) predicate.Port {
+	return predicate.Port(sql.FieldGT(FieldDeletedAt, v))
+}
+
+// DeletedAtGTE applies the GTE predicate on the "deleted_at" field.
+func DeletedAtGTE(v time.Time) predicate.Port {
+	return predicate.Port(sql.FieldGTE(FieldDeletedAt, v))
+}
+
+// DeletedAtLT applies the LT predicate on the "deleted_at" field.
+func DeletedAtLT(v time.Time) predicate.Port {
+	return predicate.Port(sql.FieldLT(FieldDeletedAt, v))
+}
+
+// DeletedAtLTE applies the LTE predicate on the "deleted_at" field.
+func DeletedAtLTE(v time.Time) predicate.Port {
+	return predicate.Port(sql.FieldLTE(FieldDeletedAt, v))
+}
+
+// DeletedAtIsNil applies the IsNil predicate on the "deleted_at" field.
+func DeletedAtIsNil() predicate.Port {
+	return predicate.Port(sql.FieldIsNull(FieldDeletedAt))
+}
+
+// DeletedAtNotNil applies the NotNil predicate on the "deleted_at" field.
+func DeletedAtNotNil() predicate.Port {
+	return predicate.Port(sql.FieldNotNull(FieldDeletedAt))
+}
+
+// DeletedByEQ applies the EQ predicate on the "deleted_by" field.
+func DeletedByEQ(v string) predicate.Port {
+	return predicate.Port(sql.FieldEQ(FieldDeletedBy, v))
+}
+
+// DeletedByNEQ applies the NEQ predicate on the "deleted_by" field.
+func DeletedByNEQ(v string) predicate.Port {
+	return predicate.Port(sql.FieldNEQ(FieldDeletedBy, v))
+}
+
+// DeletedByIn applies the In predicate on the "deleted_by" field.
+func DeletedByIn(vs ...string) predicate.Port {
+	return predicate.Port(sql.FieldIn(FieldDeletedBy, vs...))
+}
+
+// DeletedByNotIn applies the NotIn predicate on the "deleted_by" field.
+func DeletedByNotIn(vs ...string) predicate.Port {
+	return predicate.Port(sql.FieldNotIn(FieldDeletedBy, vs...))
+}
+
+// DeletedByGT applies the GT predicate on the "deleted_by" field.
+func DeletedByGT(v string) predicate.Port {
+	return predicate.Port(sql.FieldGT(FieldDeletedBy, v))
+}
+
+// DeletedByGTE applies the GTE predicate on the "deleted_by" field.
+func DeletedByGTE(v string) predicate.Port {
+	return predicate.Port(sql.FieldGTE(FieldDeletedBy, v))
+}
+
+// DeletedByLT applies the LT predicate on the "deleted_by" field.
+func DeletedByLT(v string) predicate.Port {
+	return predicate.Port(sql.FieldLT(FieldDeletedBy, v))
+}
+
+// DeletedByLTE applies the LTE predicate on the "deleted_by" field.
+func DeletedByLTE(v string) predicate.Port {
+	return predicate.Port(sql.FieldLTE(FieldDeletedBy, v))
+}
+
+// DeletedByContains applies the Contains predicate on the "deleted_by" field.
+func DeletedByContains(v string) predicate.Port {
+	return predicate.Port(sql.FieldContains(FieldDeletedBy, v))
+}
+
+// DeletedByHasPrefix applies the HasPrefix predicate on the "deleted_by" field.
+func DeletedByHasPrefix(v string) predicate.Port {
+	return predicate.Port(sql.FieldHasPrefix(FieldDeletedBy, v))
+}
+
+// DeletedByHasSuffix applies the HasSuffix predicate on the "deleted_by" field.
+func DeletedByHasSuffix(v string) predicate.Port {
+	return predicate.Port(sql.FieldHasSuffix(FieldDeletedBy, v))
+}
+
+// DeletedByIsNil applies the IsNil predicate on the "deleted_by" field.
+func DeletedByIsNil() predicate.Port {
+	return predicate.Port(sql.FieldIsNull(FieldDeletedBy))
+}
+
+// DeletedByNotNil applies the NotNil predicate on the "deleted_by" field.
+func DeletedByNotNil() predicate.Port {
+	return predicate.Port(sql.FieldNotNull(FieldDeletedBy))
+}
+
+// DeletedByEqualFold applies the EqualFold predicate on the "deleted_by" field.
+func DeletedByEqualFold(v string) predicate.Port {
+	return predicate.Port(sql.FieldEqualFold(FieldDeletedBy, v))
+}
+
+// DeletedByContainsFold applies the ContainsFold predicate on the "deleted_by" field.
+func DeletedByContainsFold(v string) predicate.Port {
+	return predicate.Port(sql.FieldContainsFold(FieldDeletedBy, v))
 }
 
 // CreatedByEQ applies the EQ predicate on the "created_by" field.

--- a/internal/ent/generated/port_create.go
+++ b/internal/ent/generated/port_create.go
@@ -65,6 +65,34 @@ func (pc *PortCreate) SetNillableUpdatedAt(t *time.Time) *PortCreate {
 	return pc
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (pc *PortCreate) SetDeletedAt(t time.Time) *PortCreate {
+	pc.mutation.SetDeletedAt(t)
+	return pc
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (pc *PortCreate) SetNillableDeletedAt(t *time.Time) *PortCreate {
+	if t != nil {
+		pc.SetDeletedAt(*t)
+	}
+	return pc
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (pc *PortCreate) SetDeletedBy(s string) *PortCreate {
+	pc.mutation.SetDeletedBy(s)
+	return pc
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (pc *PortCreate) SetNillableDeletedBy(s *string) *PortCreate {
+	if s != nil {
+		pc.SetDeletedBy(*s)
+	}
+	return pc
+}
+
 // SetCreatedBy sets the "created_by" field.
 func (pc *PortCreate) SetCreatedBy(s string) *PortCreate {
 	pc.mutation.SetCreatedBy(s)
@@ -278,6 +306,14 @@ func (pc *PortCreate) createSpec() (*Port, *sqlgraph.CreateSpec) {
 	if value, ok := pc.mutation.UpdatedAt(); ok {
 		_spec.SetField(port.FieldUpdatedAt, field.TypeTime, value)
 		_node.UpdatedAt = value
+	}
+	if value, ok := pc.mutation.DeletedAt(); ok {
+		_spec.SetField(port.FieldDeletedAt, field.TypeTime, value)
+		_node.DeletedAt = value
+	}
+	if value, ok := pc.mutation.DeletedBy(); ok {
+		_spec.SetField(port.FieldDeletedBy, field.TypeString, value)
+		_node.DeletedBy = value
 	}
 	if value, ok := pc.mutation.CreatedBy(); ok {
 		_spec.SetField(port.FieldCreatedBy, field.TypeString, value)

--- a/internal/ent/generated/port_update.go
+++ b/internal/ent/generated/port_update.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -40,6 +41,46 @@ type PortUpdate struct {
 // Where appends a list predicates to the PortUpdate builder.
 func (pu *PortUpdate) Where(ps ...predicate.Port) *PortUpdate {
 	pu.mutation.Where(ps...)
+	return pu
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (pu *PortUpdate) SetDeletedAt(t time.Time) *PortUpdate {
+	pu.mutation.SetDeletedAt(t)
+	return pu
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (pu *PortUpdate) SetNillableDeletedAt(t *time.Time) *PortUpdate {
+	if t != nil {
+		pu.SetDeletedAt(*t)
+	}
+	return pu
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (pu *PortUpdate) ClearDeletedAt() *PortUpdate {
+	pu.mutation.ClearDeletedAt()
+	return pu
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (pu *PortUpdate) SetDeletedBy(s string) *PortUpdate {
+	pu.mutation.SetDeletedBy(s)
+	return pu
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (pu *PortUpdate) SetNillableDeletedBy(s *string) *PortUpdate {
+	if s != nil {
+		pu.SetDeletedBy(*s)
+	}
+	return pu
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (pu *PortUpdate) ClearDeletedBy() *PortUpdate {
+	pu.mutation.ClearDeletedBy()
 	return pu
 }
 
@@ -193,6 +234,18 @@ func (pu *PortUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if value, ok := pu.mutation.UpdatedAt(); ok {
 		_spec.SetField(port.FieldUpdatedAt, field.TypeTime, value)
 	}
+	if value, ok := pu.mutation.DeletedAt(); ok {
+		_spec.SetField(port.FieldDeletedAt, field.TypeTime, value)
+	}
+	if pu.mutation.DeletedAtCleared() {
+		_spec.ClearField(port.FieldDeletedAt, field.TypeTime)
+	}
+	if value, ok := pu.mutation.DeletedBy(); ok {
+		_spec.SetField(port.FieldDeletedBy, field.TypeString, value)
+	}
+	if pu.mutation.DeletedByCleared() {
+		_spec.ClearField(port.FieldDeletedBy, field.TypeString)
+	}
 	if pu.mutation.CreatedByCleared() {
 		_spec.ClearField(port.FieldCreatedBy, field.TypeString)
 	}
@@ -274,6 +327,46 @@ type PortUpdateOne struct {
 	fields   []string
 	hooks    []Hook
 	mutation *PortMutation
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (puo *PortUpdateOne) SetDeletedAt(t time.Time) *PortUpdateOne {
+	puo.mutation.SetDeletedAt(t)
+	return puo
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (puo *PortUpdateOne) SetNillableDeletedAt(t *time.Time) *PortUpdateOne {
+	if t != nil {
+		puo.SetDeletedAt(*t)
+	}
+	return puo
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (puo *PortUpdateOne) ClearDeletedAt() *PortUpdateOne {
+	puo.mutation.ClearDeletedAt()
+	return puo
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (puo *PortUpdateOne) SetDeletedBy(s string) *PortUpdateOne {
+	puo.mutation.SetDeletedBy(s)
+	return puo
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (puo *PortUpdateOne) SetNillableDeletedBy(s *string) *PortUpdateOne {
+	if s != nil {
+		puo.SetDeletedBy(*s)
+	}
+	return puo
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (puo *PortUpdateOne) ClearDeletedBy() *PortUpdateOne {
+	puo.mutation.ClearDeletedBy()
+	return puo
 }
 
 // SetUpdatedBy sets the "updated_by" field.
@@ -455,6 +548,18 @@ func (puo *PortUpdateOne) sqlSave(ctx context.Context) (_node *Port, err error) 
 	}
 	if value, ok := puo.mutation.UpdatedAt(); ok {
 		_spec.SetField(port.FieldUpdatedAt, field.TypeTime, value)
+	}
+	if value, ok := puo.mutation.DeletedAt(); ok {
+		_spec.SetField(port.FieldDeletedAt, field.TypeTime, value)
+	}
+	if puo.mutation.DeletedAtCleared() {
+		_spec.ClearField(port.FieldDeletedAt, field.TypeTime)
+	}
+	if value, ok := puo.mutation.DeletedBy(); ok {
+		_spec.SetField(port.FieldDeletedBy, field.TypeString, value)
+	}
+	if puo.mutation.DeletedByCleared() {
+		_spec.ClearField(port.FieldDeletedBy, field.TypeString)
 	}
 	if puo.mutation.CreatedByCleared() {
 		_spec.ClearField(port.FieldCreatedBy, field.TypeString)

--- a/internal/ent/generated/provider.go
+++ b/internal/ent/generated/provider.go
@@ -37,6 +37,10 @@ type Provider struct {
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	// DeletedAt holds the value of the "deleted_at" field.
+	DeletedAt time.Time `json:"deleted_at,omitempty"`
+	// DeletedBy holds the value of the "deleted_by" field.
+	DeletedBy string `json:"deleted_by,omitempty"`
 	// CreatedBy holds the value of the "created_by" field.
 	CreatedBy string `json:"created_by,omitempty"`
 	// UpdatedBy holds the value of the "updated_by" field.
@@ -80,9 +84,9 @@ func (*Provider) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case provider.FieldID, provider.FieldOwnerID:
 			values[i] = new(gidx.PrefixedID)
-		case provider.FieldCreatedBy, provider.FieldUpdatedBy, provider.FieldName:
+		case provider.FieldDeletedBy, provider.FieldCreatedBy, provider.FieldUpdatedBy, provider.FieldName:
 			values[i] = new(sql.NullString)
-		case provider.FieldCreatedAt, provider.FieldUpdatedAt:
+		case provider.FieldCreatedAt, provider.FieldUpdatedAt, provider.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -116,6 +120,18 @@ func (pr *Provider) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field updated_at", values[i])
 			} else if value.Valid {
 				pr.UpdatedAt = value.Time
+			}
+		case provider.FieldDeletedAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_at", values[i])
+			} else if value.Valid {
+				pr.DeletedAt = value.Time
+			}
+		case provider.FieldDeletedBy:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field deleted_by", values[i])
+			} else if value.Valid {
+				pr.DeletedBy = value.String
 			}
 		case provider.FieldCreatedBy:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -187,6 +203,12 @@ func (pr *Provider) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("updated_at=")
 	builder.WriteString(pr.UpdatedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("deleted_at=")
+	builder.WriteString(pr.DeletedAt.Format(time.ANSIC))
+	builder.WriteString(", ")
+	builder.WriteString("deleted_by=")
+	builder.WriteString(pr.DeletedBy)
 	builder.WriteString(", ")
 	builder.WriteString("created_by=")
 	builder.WriteString(pr.CreatedBy)

--- a/internal/ent/generated/provider/provider.go
+++ b/internal/ent/generated/provider/provider.go
@@ -34,6 +34,10 @@ const (
 	FieldCreatedAt = "created_at"
 	// FieldUpdatedAt holds the string denoting the updated_at field in the database.
 	FieldUpdatedAt = "updated_at"
+	// FieldDeletedAt holds the string denoting the deleted_at field in the database.
+	FieldDeletedAt = "deleted_at"
+	// FieldDeletedBy holds the string denoting the deleted_by field in the database.
+	FieldDeletedBy = "deleted_by"
 	// FieldCreatedBy holds the string denoting the created_by field in the database.
 	FieldCreatedBy = "created_by"
 	// FieldUpdatedBy holds the string denoting the updated_by field in the database.
@@ -60,6 +64,8 @@ var Columns = []string{
 	FieldID,
 	FieldCreatedAt,
 	FieldUpdatedAt,
+	FieldDeletedAt,
+	FieldDeletedBy,
 	FieldCreatedBy,
 	FieldUpdatedBy,
 	FieldName,
@@ -82,7 +88,8 @@ func ValidColumn(column string) bool {
 //
 //	import _ "go.infratographer.com/load-balancer-api/internal/ent/generated/runtime"
 var (
-	Hooks [1]ent.Hook
+	Hooks        [2]ent.Hook
+	Interceptors [1]ent.Interceptor
 	// DefaultCreatedAt holds the default value on creation for the "created_at" field.
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
@@ -113,6 +120,16 @@ func ByCreatedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByUpdatedAt orders the results by the updated_at field.
 func ByUpdatedAt(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldUpdatedAt, opts...).ToFunc()
+}
+
+// ByDeletedAt orders the results by the deleted_at field.
+func ByDeletedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedAt, opts...).ToFunc()
+}
+
+// ByDeletedBy orders the results by the deleted_by field.
+func ByDeletedBy(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldDeletedBy, opts...).ToFunc()
 }
 
 // ByCreatedBy orders the results by the created_by field.

--- a/internal/ent/generated/provider/where.go
+++ b/internal/ent/generated/provider/where.go
@@ -80,6 +80,16 @@ func UpdatedAt(v time.Time) predicate.Provider {
 	return predicate.Provider(sql.FieldEQ(FieldUpdatedAt, v))
 }
 
+// DeletedAt applies equality check predicate on the "deleted_at" field. It's identical to DeletedAtEQ.
+func DeletedAt(v time.Time) predicate.Provider {
+	return predicate.Provider(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedBy applies equality check predicate on the "deleted_by" field. It's identical to DeletedByEQ.
+func DeletedBy(v string) predicate.Provider {
+	return predicate.Provider(sql.FieldEQ(FieldDeletedBy, v))
+}
+
 // CreatedBy applies equality check predicate on the "created_by" field. It's identical to CreatedByEQ.
 func CreatedBy(v string) predicate.Provider {
 	return predicate.Provider(sql.FieldEQ(FieldCreatedBy, v))
@@ -178,6 +188,131 @@ func UpdatedAtLT(v time.Time) predicate.Provider {
 // UpdatedAtLTE applies the LTE predicate on the "updated_at" field.
 func UpdatedAtLTE(v time.Time) predicate.Provider {
 	return predicate.Provider(sql.FieldLTE(FieldUpdatedAt, v))
+}
+
+// DeletedAtEQ applies the EQ predicate on the "deleted_at" field.
+func DeletedAtEQ(v time.Time) predicate.Provider {
+	return predicate.Provider(sql.FieldEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtNEQ applies the NEQ predicate on the "deleted_at" field.
+func DeletedAtNEQ(v time.Time) predicate.Provider {
+	return predicate.Provider(sql.FieldNEQ(FieldDeletedAt, v))
+}
+
+// DeletedAtIn applies the In predicate on the "deleted_at" field.
+func DeletedAtIn(vs ...time.Time) predicate.Provider {
+	return predicate.Provider(sql.FieldIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtNotIn applies the NotIn predicate on the "deleted_at" field.
+func DeletedAtNotIn(vs ...time.Time) predicate.Provider {
+	return predicate.Provider(sql.FieldNotIn(FieldDeletedAt, vs...))
+}
+
+// DeletedAtGT applies the GT predicate on the "deleted_at" field.
+func DeletedAtGT(v time.Time) predicate.Provider {
+	return predicate.Provider(sql.FieldGT(FieldDeletedAt, v))
+}
+
+// DeletedAtGTE applies the GTE predicate on the "deleted_at" field.
+func DeletedAtGTE(v time.Time) predicate.Provider {
+	return predicate.Provider(sql.FieldGTE(FieldDeletedAt, v))
+}
+
+// DeletedAtLT applies the LT predicate on the "deleted_at" field.
+func DeletedAtLT(v time.Time) predicate.Provider {
+	return predicate.Provider(sql.FieldLT(FieldDeletedAt, v))
+}
+
+// DeletedAtLTE applies the LTE predicate on the "deleted_at" field.
+func DeletedAtLTE(v time.Time) predicate.Provider {
+	return predicate.Provider(sql.FieldLTE(FieldDeletedAt, v))
+}
+
+// DeletedAtIsNil applies the IsNil predicate on the "deleted_at" field.
+func DeletedAtIsNil() predicate.Provider {
+	return predicate.Provider(sql.FieldIsNull(FieldDeletedAt))
+}
+
+// DeletedAtNotNil applies the NotNil predicate on the "deleted_at" field.
+func DeletedAtNotNil() predicate.Provider {
+	return predicate.Provider(sql.FieldNotNull(FieldDeletedAt))
+}
+
+// DeletedByEQ applies the EQ predicate on the "deleted_by" field.
+func DeletedByEQ(v string) predicate.Provider {
+	return predicate.Provider(sql.FieldEQ(FieldDeletedBy, v))
+}
+
+// DeletedByNEQ applies the NEQ predicate on the "deleted_by" field.
+func DeletedByNEQ(v string) predicate.Provider {
+	return predicate.Provider(sql.FieldNEQ(FieldDeletedBy, v))
+}
+
+// DeletedByIn applies the In predicate on the "deleted_by" field.
+func DeletedByIn(vs ...string) predicate.Provider {
+	return predicate.Provider(sql.FieldIn(FieldDeletedBy, vs...))
+}
+
+// DeletedByNotIn applies the NotIn predicate on the "deleted_by" field.
+func DeletedByNotIn(vs ...string) predicate.Provider {
+	return predicate.Provider(sql.FieldNotIn(FieldDeletedBy, vs...))
+}
+
+// DeletedByGT applies the GT predicate on the "deleted_by" field.
+func DeletedByGT(v string) predicate.Provider {
+	return predicate.Provider(sql.FieldGT(FieldDeletedBy, v))
+}
+
+// DeletedByGTE applies the GTE predicate on the "deleted_by" field.
+func DeletedByGTE(v string) predicate.Provider {
+	return predicate.Provider(sql.FieldGTE(FieldDeletedBy, v))
+}
+
+// DeletedByLT applies the LT predicate on the "deleted_by" field.
+func DeletedByLT(v string) predicate.Provider {
+	return predicate.Provider(sql.FieldLT(FieldDeletedBy, v))
+}
+
+// DeletedByLTE applies the LTE predicate on the "deleted_by" field.
+func DeletedByLTE(v string) predicate.Provider {
+	return predicate.Provider(sql.FieldLTE(FieldDeletedBy, v))
+}
+
+// DeletedByContains applies the Contains predicate on the "deleted_by" field.
+func DeletedByContains(v string) predicate.Provider {
+	return predicate.Provider(sql.FieldContains(FieldDeletedBy, v))
+}
+
+// DeletedByHasPrefix applies the HasPrefix predicate on the "deleted_by" field.
+func DeletedByHasPrefix(v string) predicate.Provider {
+	return predicate.Provider(sql.FieldHasPrefix(FieldDeletedBy, v))
+}
+
+// DeletedByHasSuffix applies the HasSuffix predicate on the "deleted_by" field.
+func DeletedByHasSuffix(v string) predicate.Provider {
+	return predicate.Provider(sql.FieldHasSuffix(FieldDeletedBy, v))
+}
+
+// DeletedByIsNil applies the IsNil predicate on the "deleted_by" field.
+func DeletedByIsNil() predicate.Provider {
+	return predicate.Provider(sql.FieldIsNull(FieldDeletedBy))
+}
+
+// DeletedByNotNil applies the NotNil predicate on the "deleted_by" field.
+func DeletedByNotNil() predicate.Provider {
+	return predicate.Provider(sql.FieldNotNull(FieldDeletedBy))
+}
+
+// DeletedByEqualFold applies the EqualFold predicate on the "deleted_by" field.
+func DeletedByEqualFold(v string) predicate.Provider {
+	return predicate.Provider(sql.FieldEqualFold(FieldDeletedBy, v))
+}
+
+// DeletedByContainsFold applies the ContainsFold predicate on the "deleted_by" field.
+func DeletedByContainsFold(v string) predicate.Provider {
+	return predicate.Provider(sql.FieldContainsFold(FieldDeletedBy, v))
 }
 
 // CreatedByEQ applies the EQ predicate on the "created_by" field.

--- a/internal/ent/generated/provider_create.go
+++ b/internal/ent/generated/provider_create.go
@@ -64,6 +64,34 @@ func (pc *ProviderCreate) SetNillableUpdatedAt(t *time.Time) *ProviderCreate {
 	return pc
 }
 
+// SetDeletedAt sets the "deleted_at" field.
+func (pc *ProviderCreate) SetDeletedAt(t time.Time) *ProviderCreate {
+	pc.mutation.SetDeletedAt(t)
+	return pc
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (pc *ProviderCreate) SetNillableDeletedAt(t *time.Time) *ProviderCreate {
+	if t != nil {
+		pc.SetDeletedAt(*t)
+	}
+	return pc
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (pc *ProviderCreate) SetDeletedBy(s string) *ProviderCreate {
+	pc.mutation.SetDeletedBy(s)
+	return pc
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (pc *ProviderCreate) SetNillableDeletedBy(s *string) *ProviderCreate {
+	if s != nil {
+		pc.SetDeletedBy(*s)
+	}
+	return pc
+}
+
 // SetCreatedBy sets the "created_by" field.
 func (pc *ProviderCreate) SetCreatedBy(s string) *ProviderCreate {
 	pc.mutation.SetCreatedBy(s)
@@ -260,6 +288,14 @@ func (pc *ProviderCreate) createSpec() (*Provider, *sqlgraph.CreateSpec) {
 	if value, ok := pc.mutation.UpdatedAt(); ok {
 		_spec.SetField(provider.FieldUpdatedAt, field.TypeTime, value)
 		_node.UpdatedAt = value
+	}
+	if value, ok := pc.mutation.DeletedAt(); ok {
+		_spec.SetField(provider.FieldDeletedAt, field.TypeTime, value)
+		_node.DeletedAt = value
+	}
+	if value, ok := pc.mutation.DeletedBy(); ok {
+		_spec.SetField(provider.FieldDeletedBy, field.TypeString, value)
+		_node.DeletedBy = value
 	}
 	if value, ok := pc.mutation.CreatedBy(); ok {
 		_spec.SetField(provider.FieldCreatedBy, field.TypeString, value)

--- a/internal/ent/generated/provider_update.go
+++ b/internal/ent/generated/provider_update.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -40,6 +41,46 @@ type ProviderUpdate struct {
 // Where appends a list predicates to the ProviderUpdate builder.
 func (pu *ProviderUpdate) Where(ps ...predicate.Provider) *ProviderUpdate {
 	pu.mutation.Where(ps...)
+	return pu
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (pu *ProviderUpdate) SetDeletedAt(t time.Time) *ProviderUpdate {
+	pu.mutation.SetDeletedAt(t)
+	return pu
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (pu *ProviderUpdate) SetNillableDeletedAt(t *time.Time) *ProviderUpdate {
+	if t != nil {
+		pu.SetDeletedAt(*t)
+	}
+	return pu
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (pu *ProviderUpdate) ClearDeletedAt() *ProviderUpdate {
+	pu.mutation.ClearDeletedAt()
+	return pu
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (pu *ProviderUpdate) SetDeletedBy(s string) *ProviderUpdate {
+	pu.mutation.SetDeletedBy(s)
+	return pu
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (pu *ProviderUpdate) SetNillableDeletedBy(s *string) *ProviderUpdate {
+	if s != nil {
+		pu.SetDeletedBy(*s)
+	}
+	return pu
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (pu *ProviderUpdate) ClearDeletedBy() *ProviderUpdate {
+	pu.mutation.ClearDeletedBy()
 	return pu
 }
 
@@ -177,6 +218,18 @@ func (pu *ProviderUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if value, ok := pu.mutation.UpdatedAt(); ok {
 		_spec.SetField(provider.FieldUpdatedAt, field.TypeTime, value)
 	}
+	if value, ok := pu.mutation.DeletedAt(); ok {
+		_spec.SetField(provider.FieldDeletedAt, field.TypeTime, value)
+	}
+	if pu.mutation.DeletedAtCleared() {
+		_spec.ClearField(provider.FieldDeletedAt, field.TypeTime)
+	}
+	if value, ok := pu.mutation.DeletedBy(); ok {
+		_spec.SetField(provider.FieldDeletedBy, field.TypeString, value)
+	}
+	if pu.mutation.DeletedByCleared() {
+		_spec.ClearField(provider.FieldDeletedBy, field.TypeString)
+	}
 	if pu.mutation.CreatedByCleared() {
 		_spec.ClearField(provider.FieldCreatedBy, field.TypeString)
 	}
@@ -252,6 +305,46 @@ type ProviderUpdateOne struct {
 	fields   []string
 	hooks    []Hook
 	mutation *ProviderMutation
+}
+
+// SetDeletedAt sets the "deleted_at" field.
+func (puo *ProviderUpdateOne) SetDeletedAt(t time.Time) *ProviderUpdateOne {
+	puo.mutation.SetDeletedAt(t)
+	return puo
+}
+
+// SetNillableDeletedAt sets the "deleted_at" field if the given value is not nil.
+func (puo *ProviderUpdateOne) SetNillableDeletedAt(t *time.Time) *ProviderUpdateOne {
+	if t != nil {
+		puo.SetDeletedAt(*t)
+	}
+	return puo
+}
+
+// ClearDeletedAt clears the value of the "deleted_at" field.
+func (puo *ProviderUpdateOne) ClearDeletedAt() *ProviderUpdateOne {
+	puo.mutation.ClearDeletedAt()
+	return puo
+}
+
+// SetDeletedBy sets the "deleted_by" field.
+func (puo *ProviderUpdateOne) SetDeletedBy(s string) *ProviderUpdateOne {
+	puo.mutation.SetDeletedBy(s)
+	return puo
+}
+
+// SetNillableDeletedBy sets the "deleted_by" field if the given value is not nil.
+func (puo *ProviderUpdateOne) SetNillableDeletedBy(s *string) *ProviderUpdateOne {
+	if s != nil {
+		puo.SetDeletedBy(*s)
+	}
+	return puo
+}
+
+// ClearDeletedBy clears the value of the "deleted_by" field.
+func (puo *ProviderUpdateOne) ClearDeletedBy() *ProviderUpdateOne {
+	puo.mutation.ClearDeletedBy()
+	return puo
 }
 
 // SetUpdatedBy sets the "updated_by" field.
@@ -417,6 +510,18 @@ func (puo *ProviderUpdateOne) sqlSave(ctx context.Context) (_node *Provider, err
 	}
 	if value, ok := puo.mutation.UpdatedAt(); ok {
 		_spec.SetField(provider.FieldUpdatedAt, field.TypeTime, value)
+	}
+	if value, ok := puo.mutation.DeletedAt(); ok {
+		_spec.SetField(provider.FieldDeletedAt, field.TypeTime, value)
+	}
+	if puo.mutation.DeletedAtCleared() {
+		_spec.ClearField(provider.FieldDeletedAt, field.TypeTime)
+	}
+	if value, ok := puo.mutation.DeletedBy(); ok {
+		_spec.SetField(provider.FieldDeletedBy, field.TypeString, value)
+	}
+	if puo.mutation.DeletedByCleared() {
+		_spec.ClearField(provider.FieldDeletedBy, field.TypeString)
 	}
 	if puo.mutation.CreatedByCleared() {
 		_spec.ClearField(provider.FieldCreatedBy, field.TypeString)

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -75,7 +75,11 @@ func init() {
 	loadbalancer.DefaultID = loadbalancerDescID.Default.(func() gidx.PrefixedID)
 	originMixin := schema.Origin{}.Mixin()
 	originMixinHooks1 := originMixin[1].Hooks()
+	originMixinHooks2 := originMixin[2].Hooks()
 	origin.Hooks[0] = originMixinHooks1[0]
+	origin.Hooks[1] = originMixinHooks2[0]
+	originMixinInters1 := originMixin[1].Interceptors()
+	origin.Interceptors[0] = originMixinInters1[0]
 	originMixinFields0 := originMixin[0].Fields()
 	_ = originMixinFields0
 	originFields := schema.Origin{}.Fields()
@@ -148,7 +152,11 @@ func init() {
 	origin.DefaultID = originDescID.Default.(func() gidx.PrefixedID)
 	poolMixin := schema.Pool{}.Mixin()
 	poolMixinHooks1 := poolMixin[1].Hooks()
+	poolMixinHooks2 := poolMixin[2].Hooks()
 	pool.Hooks[0] = poolMixinHooks1[0]
+	pool.Hooks[1] = poolMixinHooks2[0]
+	poolMixinInters2 := poolMixin[2].Interceptors()
+	pool.Interceptors[0] = poolMixinInters2[0]
 	poolMixinFields0 := poolMixin[0].Fields()
 	_ = poolMixinFields0
 	poolFields := schema.Pool{}.Fields()
@@ -177,7 +185,11 @@ func init() {
 	pool.DefaultID = poolDescID.Default.(func() gidx.PrefixedID)
 	portMixin := schema.Port{}.Mixin()
 	portMixinHooks1 := portMixin[1].Hooks()
+	portMixinHooks2 := portMixin[2].Hooks()
 	port.Hooks[0] = portMixinHooks1[0]
+	port.Hooks[1] = portMixinHooks2[0]
+	portMixinInters1 := portMixin[1].Interceptors()
+	port.Interceptors[0] = portMixinInters1[0]
 	portMixinFields0 := portMixin[0].Fields()
 	_ = portMixinFields0
 	portFields := schema.Port{}.Fields()
@@ -221,7 +233,11 @@ func init() {
 	port.DefaultID = portDescID.Default.(func() gidx.PrefixedID)
 	providerMixin := schema.Provider{}.Mixin()
 	providerMixinHooks1 := providerMixin[1].Hooks()
+	providerMixinHooks2 := providerMixin[2].Hooks()
 	provider.Hooks[0] = providerMixinHooks1[0]
+	provider.Hooks[1] = providerMixinHooks2[0]
+	providerMixinInters1 := providerMixin[1].Interceptors()
+	provider.Interceptors[0] = providerMixinInters1[0]
 	providerMixinFields0 := providerMixin[0].Fields()
 	_ = providerMixinFields0
 	providerFields := schema.Provider{}.Fields()

--- a/internal/ent/generated/runtime/runtime.go
+++ b/internal/ent/generated/runtime/runtime.go
@@ -34,7 +34,11 @@ import (
 func init() {
 	loadbalancerMixin := schema.LoadBalancer{}.Mixin()
 	loadbalancerMixinHooks1 := loadbalancerMixin[1].Hooks()
+	loadbalancerMixinHooks2 := loadbalancerMixin[2].Hooks()
 	loadbalancer.Hooks[0] = loadbalancerMixinHooks1[0]
+	loadbalancer.Hooks[1] = loadbalancerMixinHooks2[0]
+	loadbalancerMixinInters2 := loadbalancerMixin[2].Interceptors()
+	loadbalancer.Interceptors[0] = loadbalancerMixinInters2[0]
 	loadbalancerMixinFields0 := loadbalancerMixin[0].Fields()
 	_ = loadbalancerMixinFields0
 	loadbalancerFields := schema.LoadBalancer{}.Fields()

--- a/internal/ent/schema/loadbalancer.go
+++ b/internal/ent/schema/loadbalancer.go
@@ -13,6 +13,7 @@ import (
 	"go.infratographer.com/x/gidx"
 
 	"go.infratographer.com/load-balancer-api/internal/ent/schema/audit"
+	"go.infratographer.com/load-balancer-api/internal/ent/schema/softdelete"
 	"go.infratographer.com/load-balancer-api/x/pubsubinfo"
 )
 
@@ -26,7 +27,7 @@ func (LoadBalancer) Mixin() []ent.Mixin {
 	return []ent.Mixin{
 		entx.NewTimestampMixin(),
 		audit.Mixin{},
-		// softdelete.Mixin{},
+		softdelete.Mixin{},
 	}
 }
 

--- a/internal/ent/schema/origin.go
+++ b/internal/ent/schema/origin.go
@@ -12,6 +12,7 @@ import (
 	"go.infratographer.com/x/gidx"
 
 	"go.infratographer.com/load-balancer-api/internal/ent/schema/audit"
+	"go.infratographer.com/load-balancer-api/internal/ent/schema/softdelete"
 	"go.infratographer.com/load-balancer-api/internal/ent/schema/validations"
 	"go.infratographer.com/load-balancer-api/x/pubsubinfo"
 )
@@ -27,6 +28,7 @@ type Origin struct {
 func (Origin) Mixin() []ent.Mixin {
 	return []ent.Mixin{
 		entx.NewTimestampMixin(),
+		softdelete.Mixin{},
 		audit.Mixin{},
 	}
 }

--- a/internal/ent/schema/pool.go
+++ b/internal/ent/schema/pool.go
@@ -12,6 +12,7 @@ import (
 	"go.infratographer.com/x/gidx"
 
 	"go.infratographer.com/load-balancer-api/internal/ent/schema/audit"
+	"go.infratographer.com/load-balancer-api/internal/ent/schema/softdelete"
 	"go.infratographer.com/load-balancer-api/x/pubsubinfo"
 )
 
@@ -25,6 +26,7 @@ func (Pool) Mixin() []ent.Mixin {
 	return []ent.Mixin{
 		entx.NewTimestampMixin(),
 		audit.Mixin{},
+		softdelete.Mixin{},
 	}
 }
 

--- a/internal/ent/schema/port.go
+++ b/internal/ent/schema/port.go
@@ -12,6 +12,7 @@ import (
 	"go.infratographer.com/x/gidx"
 
 	"go.infratographer.com/load-balancer-api/internal/ent/schema/audit"
+	"go.infratographer.com/load-balancer-api/internal/ent/schema/softdelete"
 	"go.infratographer.com/load-balancer-api/internal/ent/schema/validations"
 	"go.infratographer.com/load-balancer-api/x/pubsubinfo"
 )
@@ -30,6 +31,7 @@ type Port struct {
 func (Port) Mixin() []ent.Mixin {
 	return []ent.Mixin{
 		entx.NewTimestampMixin(),
+		softdelete.Mixin{},
 		audit.Mixin{},
 	}
 }

--- a/internal/ent/schema/provider.go
+++ b/internal/ent/schema/provider.go
@@ -11,6 +11,7 @@ import (
 	"go.infratographer.com/x/gidx"
 
 	"go.infratographer.com/load-balancer-api/internal/ent/schema/audit"
+	"go.infratographer.com/load-balancer-api/internal/ent/schema/softdelete"
 	"go.infratographer.com/load-balancer-api/x/pubsubinfo"
 )
 
@@ -23,6 +24,7 @@ type Provider struct {
 func (Provider) Mixin() []ent.Mixin {
 	return []ent.Mixin{
 		entx.NewTimestampMixin(),
+		softdelete.Mixin{},
 		audit.Mixin{},
 	}
 }

--- a/internal/ent/schema/softdelete/mixin.go
+++ b/internal/ent/schema/softdelete/mixin.go
@@ -15,6 +15,7 @@ import (
 	"go.infratographer.com/load-balancer-api/internal/ent/generated"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/hook"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/intercept"
+
 	"go.infratographer.com/x/echojwtx"
 )
 

--- a/internal/ent/schema/softdelete/mixin.go
+++ b/internal/ent/schema/softdelete/mixin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/contrib/entgql"
 	"entgo.io/ent"
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/schema/field"
@@ -14,6 +15,7 @@ import (
 	"go.infratographer.com/load-balancer-api/internal/ent/generated"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/hook"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/intercept"
+	"go.infratographer.com/x/echojwtx"
 )
 
 // Mixin implements the soft delete pattern for schemas.
@@ -25,7 +27,17 @@ type Mixin struct {
 func (Mixin) Fields() []ent.Field {
 	return []ent.Field{
 		field.Time("deleted_at").
-			Optional(),
+			Optional().
+			Annotations(
+				entgql.OrderField("DELETED_AT"),
+				entgql.Skip(entgql.SkipMutationCreateInput, entgql.SkipMutationUpdateInput),
+			),
+		field.String("deleted_by").
+			Optional().
+			Annotations(
+				entgql.OrderField("DELETED_BY"),
+				entgql.Skip(entgql.SkipMutationCreateInput, entgql.SkipMutationUpdateInput),
+			),
 	}
 }
 
@@ -60,10 +72,19 @@ func (d Mixin) Hooks() []ent.Hook {
 					if skip, _ := ctx.Value(softDeleteKey{}).(bool); skip {
 						return next.Mutate(ctx, m)
 					}
+
+					actor := "unknown-actor"
+
+					id, ok := ctx.Value(echojwtx.ActorCtxKey).(string)
+					if ok {
+						actor = id
+					}
+
 					mx, ok := m.(interface {
 						SetOp(ent.Op)
 						Client() *generated.Client
 						SetDeletedAt(time.Time)
+						SetDeletedBy(string)
 						WhereP(...func(*sql.Selector))
 					})
 					if !ok {
@@ -72,6 +93,7 @@ func (d Mixin) Hooks() []ent.Hook {
 					d.P(mx)
 					mx.SetOp(ent.OpUpdate)
 					mx.SetDeletedAt(time.Now())
+					mx.SetDeletedBy(actor)
 					return mx.Client().Mutate(ctx, m)
 				})
 			},

--- a/internal/graphapi/gen_server.go
+++ b/internal/graphapi/gen_server.go
@@ -69,6 +69,8 @@ type ComplexityRoot struct {
 	LoadBalancer struct {
 		CreatedAt func(childComplexity int) int
 		CreatedBy func(childComplexity int) int
+		DeletedAt func(childComplexity int) int
+		DeletedBy func(childComplexity int) int
 		ID        func(childComplexity int) int
 		Location  func(childComplexity int) int
 		Name      func(childComplexity int) int
@@ -461,6 +463,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.LoadBalancer.CreatedBy(childComplexity), true
+
+	case "LoadBalancer.deletedAt":
+		if e.complexity.LoadBalancer.DeletedAt == nil {
+			break
+		}
+
+		return e.complexity.LoadBalancer.DeletedAt(childComplexity), true
+
+	case "LoadBalancer.deletedBy":
+		if e.complexity.LoadBalancer.DeletedBy == nil {
+			break
+		}
+
+		return e.complexity.LoadBalancer.DeletedBy(childComplexity), true
 
 	case "LoadBalancer.id":
 		if e.complexity.LoadBalancer.ID == nil {
@@ -1636,6 +1652,8 @@ type LoadBalancer implements Node & IPAddressable & MetadataNode @key(fields: "i
   updatedAt: Time!
   createdBy: String
   updatedBy: String
+  deletedAt: Time
+  deletedBy: String
   """The name of the load balancer."""
   name: String!
   ports(
@@ -1690,6 +1708,8 @@ enum LoadBalancerOrderField {
   UPDATED_AT
   CREATED_BY
   UPDATED_BY
+  DELETED_AT
+  DELETED_BY
   NAME
   OWNER
 }
@@ -2377,6 +2397,33 @@ input LoadBalancerWhereInput {
   updatedByNotNil: Boolean
   updatedByEqualFold: String
   updatedByContainsFold: String
+  """deleted_at field predicates"""
+  deletedAt: Time
+  deletedAtNEQ: Time
+  deletedAtIn: [Time!]
+  deletedAtNotIn: [Time!]
+  deletedAtGT: Time
+  deletedAtGTE: Time
+  deletedAtLT: Time
+  deletedAtLTE: Time
+  deletedAtIsNil: Boolean
+  deletedAtNotNil: Boolean
+  """deleted_by field predicates"""
+  deletedBy: String
+  deletedByNEQ: String
+  deletedByIn: [String!]
+  deletedByNotIn: [String!]
+  deletedByGT: String
+  deletedByGTE: String
+  deletedByLT: String
+  deletedByLTE: String
+  deletedByContains: String
+  deletedByHasPrefix: String
+  deletedByHasSuffix: String
+  deletedByIsNil: Boolean
+  deletedByNotNil: Boolean
+  deletedByEqualFold: String
+  deletedByContainsFold: String
   """name field predicates"""
   name: String
   nameNEQ: String
@@ -4053,6 +4100,10 @@ func (ec *executionContext) fieldContext_Entity_findLoadBalancerByID(ctx context
 				return ec.fieldContext_LoadBalancer_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancer_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancer_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancer_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancer_name(ctx, field)
 			case "ports":
@@ -4731,6 +4782,88 @@ func (ec *executionContext) fieldContext_LoadBalancer_updatedBy(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _LoadBalancer_deletedAt(ctx context.Context, field graphql.CollectedField, obj *generated.LoadBalancer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LoadBalancer_deletedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalOTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LoadBalancer_deletedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LoadBalancer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LoadBalancer_deletedBy(ctx context.Context, field graphql.CollectedField, obj *generated.LoadBalancer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LoadBalancer_deletedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LoadBalancer_deletedBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LoadBalancer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _LoadBalancer_name(ctx context.Context, field graphql.CollectedField, obj *generated.LoadBalancer) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_LoadBalancer_name(ctx, field)
 	if err != nil {
@@ -5198,6 +5331,10 @@ func (ec *executionContext) fieldContext_LoadBalancerCreatePayload_loadBalancer(
 				return ec.fieldContext_LoadBalancer_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancer_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancer_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancer_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancer_name(ctx, field)
 			case "ports":
@@ -5305,6 +5442,10 @@ func (ec *executionContext) fieldContext_LoadBalancerEdge_node(ctx context.Conte
 				return ec.fieldContext_LoadBalancer_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancer_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancer_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancer_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancer_name(ctx, field)
 			case "ports":
@@ -7769,6 +7910,10 @@ func (ec *executionContext) fieldContext_LoadBalancerPort_loadBalancer(ctx conte
 				return ec.fieldContext_LoadBalancer_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancer_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancer_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancer_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancer_name(ctx, field)
 			case "ports":
@@ -9054,6 +9199,10 @@ func (ec *executionContext) fieldContext_LoadBalancerUpdatePayload_loadBalancer(
 				return ec.fieldContext_LoadBalancer_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancer_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancer_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancer_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancer_name(ctx, field)
 			case "ports":
@@ -10345,6 +10494,10 @@ func (ec *executionContext) fieldContext_Query_loadBalancer(ctx context.Context,
 				return ec.fieldContext_LoadBalancer_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancer_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancer_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancer_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancer_name(ctx, field)
 			case "ports":
@@ -16414,7 +16567,7 @@ func (ec *executionContext) unmarshalInputLoadBalancerWhereInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "createdAt", "createdAtNEQ", "createdAtIn", "createdAtNotIn", "createdAtGT", "createdAtGTE", "createdAtLT", "createdAtLTE", "updatedAt", "updatedAtNEQ", "updatedAtIn", "updatedAtNotIn", "updatedAtGT", "updatedAtGTE", "updatedAtLT", "updatedAtLTE", "createdBy", "createdByNEQ", "createdByIn", "createdByNotIn", "createdByGT", "createdByGTE", "createdByLT", "createdByLTE", "createdByContains", "createdByHasPrefix", "createdByHasSuffix", "createdByIsNil", "createdByNotNil", "createdByEqualFold", "createdByContainsFold", "updatedBy", "updatedByNEQ", "updatedByIn", "updatedByNotIn", "updatedByGT", "updatedByGTE", "updatedByLT", "updatedByLTE", "updatedByContains", "updatedByHasPrefix", "updatedByHasSuffix", "updatedByIsNil", "updatedByNotNil", "updatedByEqualFold", "updatedByContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "hasPorts", "hasPortsWith", "hasProvider", "hasProviderWith"}
+	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "createdAt", "createdAtNEQ", "createdAtIn", "createdAtNotIn", "createdAtGT", "createdAtGTE", "createdAtLT", "createdAtLTE", "updatedAt", "updatedAtNEQ", "updatedAtIn", "updatedAtNotIn", "updatedAtGT", "updatedAtGTE", "updatedAtLT", "updatedAtLTE", "createdBy", "createdByNEQ", "createdByIn", "createdByNotIn", "createdByGT", "createdByGTE", "createdByLT", "createdByLTE", "createdByContains", "createdByHasPrefix", "createdByHasSuffix", "createdByIsNil", "createdByNotNil", "createdByEqualFold", "createdByContainsFold", "updatedBy", "updatedByNEQ", "updatedByIn", "updatedByNotIn", "updatedByGT", "updatedByGTE", "updatedByLT", "updatedByLTE", "updatedByContains", "updatedByHasPrefix", "updatedByHasSuffix", "updatedByIsNil", "updatedByNotNil", "updatedByEqualFold", "updatedByContainsFold", "deletedAt", "deletedAtNEQ", "deletedAtIn", "deletedAtNotIn", "deletedAtGT", "deletedAtGTE", "deletedAtLT", "deletedAtLTE", "deletedAtIsNil", "deletedAtNotNil", "deletedBy", "deletedByNEQ", "deletedByIn", "deletedByNotIn", "deletedByGT", "deletedByGTE", "deletedByLT", "deletedByLTE", "deletedByContains", "deletedByHasPrefix", "deletedByHasSuffix", "deletedByIsNil", "deletedByNotNil", "deletedByEqualFold", "deletedByContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "hasPorts", "hasPortsWith", "hasProvider", "hasProviderWith"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -16934,6 +17087,231 @@ func (ec *executionContext) unmarshalInputLoadBalancerWhereInput(ctx context.Con
 				return it, err
 			}
 			it.UpdatedByContainsFold = data
+		case "deletedAt":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAt"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAt = data
+		case "deletedAtNEQ":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNEQ"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNEQ = data
+		case "deletedAtIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtIn"))
+			data, err := ec.unmarshalOTime2ᚕtimeᚐTimeᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtIn = data
+		case "deletedAtNotIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNotIn"))
+			data, err := ec.unmarshalOTime2ᚕtimeᚐTimeᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNotIn = data
+		case "deletedAtGT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtGT"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtGT = data
+		case "deletedAtGTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtGTE"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtGTE = data
+		case "deletedAtLT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtLT"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtLT = data
+		case "deletedAtLTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtLTE"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtLTE = data
+		case "deletedAtIsNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtIsNil = data
+		case "deletedAtNotNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNotNil = data
+		case "deletedBy":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedBy"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedBy = data
+		case "deletedByNEQ":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNEQ"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNEQ = data
+		case "deletedByIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByIn = data
+		case "deletedByNotIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNotIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNotIn = data
+		case "deletedByGT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByGT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByGT = data
+		case "deletedByGTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByGTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByGTE = data
+		case "deletedByLT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByLT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByLT = data
+		case "deletedByLTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByLTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByLTE = data
+		case "deletedByContains":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByContains"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByContains = data
+		case "deletedByHasPrefix":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByHasPrefix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByHasPrefix = data
+		case "deletedByHasSuffix":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByHasSuffix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByHasSuffix = data
+		case "deletedByIsNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByIsNil = data
+		case "deletedByNotNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNotNil = data
+		case "deletedByEqualFold":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByEqualFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByEqualFold = data
+		case "deletedByContainsFold":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByContainsFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByContainsFold = data
 		case "name":
 			var err error
 
@@ -17758,6 +18136,10 @@ func (ec *executionContext) _LoadBalancer(ctx context.Context, sel ast.Selection
 			out.Values[i] = ec._LoadBalancer_createdBy(ctx, field, obj)
 		case "updatedBy":
 			out.Values[i] = ec._LoadBalancer_updatedBy(ctx, field, obj)
+		case "deletedAt":
+			out.Values[i] = ec._LoadBalancer_deletedAt(ctx, field, obj)
+		case "deletedBy":
+			out.Values[i] = ec._LoadBalancer_deletedBy(ctx, field, obj)
 		case "name":
 			out.Values[i] = ec._LoadBalancer_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -22363,6 +22745,16 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 		return graphql.Null
 	}
 	res := graphql.MarshalString(*v)
+	return res
+}
+
+func (ec *executionContext) unmarshalOTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {
+	res, err := graphql.UnmarshalTime(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTime2timeᚐTime(ctx context.Context, sel ast.SelectionSet, v time.Time) graphql.Marshaler {
+	res := graphql.MarshalTime(v)
 	return res
 }
 

--- a/internal/graphapi/gen_server.go
+++ b/internal/graphapi/gen_server.go
@@ -104,6 +104,8 @@ type ComplexityRoot struct {
 		Active     func(childComplexity int) int
 		CreatedAt  func(childComplexity int) int
 		CreatedBy  func(childComplexity int) int
+		DeletedAt  func(childComplexity int) int
+		DeletedBy  func(childComplexity int) int
 		ID         func(childComplexity int) int
 		Name       func(childComplexity int) int
 		Pool       func(childComplexity int) int
@@ -141,6 +143,8 @@ type ComplexityRoot struct {
 	LoadBalancerPool struct {
 		CreatedAt func(childComplexity int) int
 		CreatedBy func(childComplexity int) int
+		DeletedAt func(childComplexity int) int
+		DeletedBy func(childComplexity int) int
 		ID        func(childComplexity int) int
 		Name      func(childComplexity int) int
 		Origins   func(childComplexity int, after *entgql.Cursor[gidx.PrefixedID], first *int, before *entgql.Cursor[gidx.PrefixedID], last *int, orderBy *generated.LoadBalancerOriginOrder, where *generated.LoadBalancerOriginWhereInput) int
@@ -178,6 +182,8 @@ type ComplexityRoot struct {
 	LoadBalancerPort struct {
 		CreatedAt      func(childComplexity int) int
 		CreatedBy      func(childComplexity int) int
+		DeletedAt      func(childComplexity int) int
+		DeletedBy      func(childComplexity int) int
 		ID             func(childComplexity int) int
 		LoadBalancer   func(childComplexity int) int
 		LoadBalancerID func(childComplexity int) int
@@ -214,6 +220,8 @@ type ComplexityRoot struct {
 	LoadBalancerProvider struct {
 		CreatedAt     func(childComplexity int) int
 		CreatedBy     func(childComplexity int) int
+		DeletedAt     func(childComplexity int) int
+		DeletedBy     func(childComplexity int) int
 		ID            func(childComplexity int) int
 		LoadBalancers func(childComplexity int, after *entgql.Cursor[gidx.PrefixedID], first *int, before *entgql.Cursor[gidx.PrefixedID], last *int, orderBy *generated.LoadBalancerOrder, where *generated.LoadBalancerWhereInput) int
 		Name          func(childComplexity int) int
@@ -609,6 +617,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.LoadBalancerOrigin.CreatedBy(childComplexity), true
 
+	case "LoadBalancerOrigin.deletedAt":
+		if e.complexity.LoadBalancerOrigin.DeletedAt == nil {
+			break
+		}
+
+		return e.complexity.LoadBalancerOrigin.DeletedAt(childComplexity), true
+
+	case "LoadBalancerOrigin.deletedBy":
+		if e.complexity.LoadBalancerOrigin.DeletedBy == nil {
+			break
+		}
+
+		return e.complexity.LoadBalancerOrigin.DeletedBy(childComplexity), true
+
 	case "LoadBalancerOrigin.id":
 		if e.complexity.LoadBalancerOrigin.ID == nil {
 			break
@@ -741,6 +763,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.LoadBalancerPool.CreatedBy(childComplexity), true
+
+	case "LoadBalancerPool.deletedAt":
+		if e.complexity.LoadBalancerPool.DeletedAt == nil {
+			break
+		}
+
+		return e.complexity.LoadBalancerPool.DeletedAt(childComplexity), true
+
+	case "LoadBalancerPool.deletedBy":
+		if e.complexity.LoadBalancerPool.DeletedBy == nil {
+			break
+		}
+
+		return e.complexity.LoadBalancerPool.DeletedBy(childComplexity), true
 
 	case "LoadBalancerPool.id":
 		if e.complexity.LoadBalancerPool.ID == nil {
@@ -880,6 +916,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.LoadBalancerPort.CreatedBy(childComplexity), true
 
+	case "LoadBalancerPort.deletedAt":
+		if e.complexity.LoadBalancerPort.DeletedAt == nil {
+			break
+		}
+
+		return e.complexity.LoadBalancerPort.DeletedAt(childComplexity), true
+
+	case "LoadBalancerPort.deletedBy":
+		if e.complexity.LoadBalancerPort.DeletedBy == nil {
+			break
+		}
+
+		return e.complexity.LoadBalancerPort.DeletedBy(childComplexity), true
+
 	case "LoadBalancerPort.id":
 		if e.complexity.LoadBalancerPort.ID == nil {
 			break
@@ -1005,6 +1055,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.LoadBalancerProvider.CreatedBy(childComplexity), true
+
+	case "LoadBalancerProvider.deletedAt":
+		if e.complexity.LoadBalancerProvider.DeletedAt == nil {
+			break
+		}
+
+		return e.complexity.LoadBalancerProvider.DeletedAt(childComplexity), true
+
+	case "LoadBalancerProvider.deletedBy":
+		if e.complexity.LoadBalancerProvider.DeletedBy == nil {
+			break
+		}
+
+		return e.complexity.LoadBalancerProvider.DeletedBy(childComplexity), true
 
 	case "LoadBalancerProvider.id":
 		if e.complexity.LoadBalancerProvider.ID == nil {
@@ -1717,6 +1781,8 @@ type LoadBalancerOrigin implements Node @key(fields: "id") @prefixedID(prefix: "
   id: ID!
   createdAt: Time!
   updatedAt: Time!
+  deletedAt: Time
+  deletedBy: String
   createdBy: String
   updatedBy: String
   name: String!
@@ -1754,6 +1820,8 @@ input LoadBalancerOriginOrder {
 enum LoadBalancerOriginOrderField {
   CREATED_AT
   UPDATED_AT
+  DELETED_AT
+  DELETED_BY
   CREATED_BY
   UPDATED_BY
   name
@@ -1797,6 +1865,33 @@ input LoadBalancerOriginWhereInput {
   updatedAtGTE: Time
   updatedAtLT: Time
   updatedAtLTE: Time
+  """deleted_at field predicates"""
+  deletedAt: Time
+  deletedAtNEQ: Time
+  deletedAtIn: [Time!]
+  deletedAtNotIn: [Time!]
+  deletedAtGT: Time
+  deletedAtGTE: Time
+  deletedAtLT: Time
+  deletedAtLTE: Time
+  deletedAtIsNil: Boolean
+  deletedAtNotNil: Boolean
+  """deleted_by field predicates"""
+  deletedBy: String
+  deletedByNEQ: String
+  deletedByIn: [String!]
+  deletedByNotIn: [String!]
+  deletedByGT: String
+  deletedByGTE: String
+  deletedByLT: String
+  deletedByLTE: String
+  deletedByContains: String
+  deletedByHasPrefix: String
+  deletedByHasSuffix: String
+  deletedByIsNil: Boolean
+  deletedByNotNil: Boolean
+  deletedByEqualFold: String
+  deletedByContainsFold: String
   """created_by field predicates"""
   createdBy: String
   createdByNEQ: String
@@ -1888,6 +1983,8 @@ type LoadBalancerPool implements Node @key(fields: "id") @prefixedID(prefix: "lo
   updatedAt: Time!
   createdBy: String
   updatedBy: String
+  deletedAt: Time
+  deletedBy: String
   name: String!
   protocol: LoadBalancerPoolProtocol!
   ownerID: ID!
@@ -1941,6 +2038,8 @@ enum LoadBalancerPoolOrderField {
   UPDATED_AT
   CREATED_BY
   UPDATED_BY
+  DELETED_AT
+  DELETED_BY
   name
   protocol
 }
@@ -2016,6 +2115,33 @@ input LoadBalancerPoolWhereInput {
   updatedByNotNil: Boolean
   updatedByEqualFold: String
   updatedByContainsFold: String
+  """deleted_at field predicates"""
+  deletedAt: Time
+  deletedAtNEQ: Time
+  deletedAtIn: [Time!]
+  deletedAtNotIn: [Time!]
+  deletedAtGT: Time
+  deletedAtGTE: Time
+  deletedAtLT: Time
+  deletedAtLTE: Time
+  deletedAtIsNil: Boolean
+  deletedAtNotNil: Boolean
+  """deleted_by field predicates"""
+  deletedBy: String
+  deletedByNEQ: String
+  deletedByIn: [String!]
+  deletedByNotIn: [String!]
+  deletedByGT: String
+  deletedByGTE: String
+  deletedByLT: String
+  deletedByLTE: String
+  deletedByContains: String
+  deletedByHasPrefix: String
+  deletedByHasSuffix: String
+  deletedByIsNil: Boolean
+  deletedByNotNil: Boolean
+  deletedByEqualFold: String
+  deletedByContainsFold: String
   """name field predicates"""
   name: String
   nameNEQ: String
@@ -2046,6 +2172,8 @@ type LoadBalancerPort implements Node @key(fields: "id") @prefixedID(prefix: "lo
   id: ID!
   createdAt: Time!
   updatedAt: Time!
+  deletedAt: Time
+  deletedBy: String
   createdBy: String
   updatedBy: String
   number: Int!
@@ -2081,6 +2209,8 @@ input LoadBalancerPortOrder {
 enum LoadBalancerPortOrderField {
   CREATED_AT
   UPDATED_AT
+  DELETED_AT
+  DELETED_BY
   CREATED_BY
   UPDATED_BY
   number
@@ -2121,6 +2251,33 @@ input LoadBalancerPortWhereInput {
   updatedAtGTE: Time
   updatedAtLT: Time
   updatedAtLTE: Time
+  """deleted_at field predicates"""
+  deletedAt: Time
+  deletedAtNEQ: Time
+  deletedAtIn: [Time!]
+  deletedAtNotIn: [Time!]
+  deletedAtGT: Time
+  deletedAtGTE: Time
+  deletedAtLT: Time
+  deletedAtLTE: Time
+  deletedAtIsNil: Boolean
+  deletedAtNotNil: Boolean
+  """deleted_by field predicates"""
+  deletedBy: String
+  deletedByNEQ: String
+  deletedByIn: [String!]
+  deletedByNotIn: [String!]
+  deletedByGT: String
+  deletedByGTE: String
+  deletedByLT: String
+  deletedByLTE: String
+  deletedByContains: String
+  deletedByHasPrefix: String
+  deletedByHasSuffix: String
+  deletedByIsNil: Boolean
+  deletedByNotNil: Boolean
+  deletedByEqualFold: String
+  deletedByContainsFold: String
   """created_by field predicates"""
   createdBy: String
   createdByNEQ: String
@@ -2188,6 +2345,8 @@ type LoadBalancerProvider implements Node @key(fields: "id") @prefixedID(prefix:
   id: ID!
   createdAt: Time!
   updatedAt: Time!
+  deletedAt: Time
+  deletedBy: String
   createdBy: String
   updatedBy: String
   """The name of the load balancer provider."""
@@ -2240,6 +2399,8 @@ enum LoadBalancerProviderOrderField {
   ID
   CREATED_AT
   UPDATED_AT
+  DELETED_AT
+  DELETED_BY
   CREATED_BY
   UPDATED_BY
   NAME
@@ -2280,6 +2441,33 @@ input LoadBalancerProviderWhereInput {
   updatedAtGTE: Time
   updatedAtLT: Time
   updatedAtLTE: Time
+  """deleted_at field predicates"""
+  deletedAt: Time
+  deletedAtNEQ: Time
+  deletedAtIn: [Time!]
+  deletedAtNotIn: [Time!]
+  deletedAtGT: Time
+  deletedAtGTE: Time
+  deletedAtLT: Time
+  deletedAtLTE: Time
+  deletedAtIsNil: Boolean
+  deletedAtNotNil: Boolean
+  """deleted_by field predicates"""
+  deletedBy: String
+  deletedByNEQ: String
+  deletedByIn: [String!]
+  deletedByNotIn: [String!]
+  deletedByGT: String
+  deletedByGTE: String
+  deletedByLT: String
+  deletedByLTE: String
+  deletedByContains: String
+  deletedByHasPrefix: String
+  deletedByHasSuffix: String
+  deletedByIsNil: Boolean
+  deletedByNotNil: Boolean
+  deletedByEqualFold: String
+  deletedByContainsFold: String
   """created_by field predicates"""
   createdBy: String
   createdByNEQ: String
@@ -4177,6 +4365,10 @@ func (ec *executionContext) fieldContext_Entity_findLoadBalancerOriginByID(ctx c
 				return ec.fieldContext_LoadBalancerOrigin_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerOrigin_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerOrigin_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerOrigin_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerOrigin_createdBy(ctx, field)
 			case "updatedBy":
@@ -4262,6 +4454,10 @@ func (ec *executionContext) fieldContext_Entity_findLoadBalancerPoolByID(ctx con
 				return ec.fieldContext_LoadBalancerPool_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancerPool_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerPool_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerPool_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancerPool_name(ctx, field)
 			case "protocol":
@@ -4337,6 +4533,10 @@ func (ec *executionContext) fieldContext_Entity_findLoadBalancerPortByID(ctx con
 				return ec.fieldContext_LoadBalancerPort_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerPort_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerPort_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerPort_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerPort_createdBy(ctx, field)
 			case "updatedBy":
@@ -4414,6 +4614,10 @@ func (ec *executionContext) fieldContext_Entity_findLoadBalancerProviderByID(ctx
 				return ec.fieldContext_LoadBalancerProvider_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerProvider_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerProvider_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerProvider_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerProvider_createdBy(ctx, field)
 			case "updatedBy":
@@ -5016,6 +5220,10 @@ func (ec *executionContext) fieldContext_LoadBalancer_loadBalancerProvider(ctx c
 				return ec.fieldContext_LoadBalancerProvider_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerProvider_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerProvider_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerProvider_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerProvider_createdBy(ctx, field)
 			case "updatedBy":
@@ -5639,6 +5847,88 @@ func (ec *executionContext) fieldContext_LoadBalancerOrigin_updatedAt(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _LoadBalancerOrigin_deletedAt(ctx context.Context, field graphql.CollectedField, obj *generated.Origin) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LoadBalancerOrigin_deletedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalOTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LoadBalancerOrigin_deletedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LoadBalancerOrigin",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LoadBalancerOrigin_deletedBy(ctx context.Context, field graphql.CollectedField, obj *generated.Origin) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LoadBalancerOrigin_deletedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LoadBalancerOrigin_deletedBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LoadBalancerOrigin",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _LoadBalancerOrigin_createdBy(ctx context.Context, field graphql.CollectedField, obj *generated.Origin) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_LoadBalancerOrigin_createdBy(ctx, field)
 	if err != nil {
@@ -6034,6 +6324,10 @@ func (ec *executionContext) fieldContext_LoadBalancerOrigin_pool(ctx context.Con
 				return ec.fieldContext_LoadBalancerPool_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancerPool_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerPool_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerPool_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancerPool_name(ctx, field)
 			case "protocol":
@@ -6243,6 +6537,10 @@ func (ec *executionContext) fieldContext_LoadBalancerOriginCreatePayload_loadBal
 				return ec.fieldContext_LoadBalancerOrigin_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerOrigin_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerOrigin_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerOrigin_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerOrigin_createdBy(ctx, field)
 			case "updatedBy":
@@ -6354,6 +6652,10 @@ func (ec *executionContext) fieldContext_LoadBalancerOriginEdge_node(ctx context
 				return ec.fieldContext_LoadBalancerOrigin_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerOrigin_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerOrigin_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerOrigin_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerOrigin_createdBy(ctx, field)
 			case "updatedBy":
@@ -6468,6 +6770,10 @@ func (ec *executionContext) fieldContext_LoadBalancerOriginUpdatePayload_loadBal
 				return ec.fieldContext_LoadBalancerOrigin_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerOrigin_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerOrigin_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerOrigin_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerOrigin_createdBy(ctx, field)
 			case "updatedBy":
@@ -6707,6 +7013,88 @@ func (ec *executionContext) fieldContext_LoadBalancerPool_updatedBy(ctx context.
 	return fc, nil
 }
 
+func (ec *executionContext) _LoadBalancerPool_deletedAt(ctx context.Context, field graphql.CollectedField, obj *generated.Pool) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LoadBalancerPool_deletedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalOTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LoadBalancerPool_deletedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LoadBalancerPool",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LoadBalancerPool_deletedBy(ctx context.Context, field graphql.CollectedField, obj *generated.Pool) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LoadBalancerPool_deletedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LoadBalancerPool_deletedBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LoadBalancerPool",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _LoadBalancerPool_name(ctx context.Context, field graphql.CollectedField, obj *generated.Pool) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_LoadBalancerPool_name(ctx, field)
 	if err != nil {
@@ -6881,6 +7269,10 @@ func (ec *executionContext) fieldContext_LoadBalancerPool_ports(ctx context.Cont
 				return ec.fieldContext_LoadBalancerPort_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerPort_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerPort_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerPort_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerPort_createdBy(ctx, field)
 			case "updatedBy":
@@ -7213,6 +7605,10 @@ func (ec *executionContext) fieldContext_LoadBalancerPoolCreatePayload_loadBalan
 				return ec.fieldContext_LoadBalancerPool_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancerPool_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerPool_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerPool_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancerPool_name(ctx, field)
 			case "protocol":
@@ -7319,6 +7715,10 @@ func (ec *executionContext) fieldContext_LoadBalancerPoolEdge_node(ctx context.C
 				return ec.fieldContext_LoadBalancerPool_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancerPool_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerPool_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerPool_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancerPool_name(ctx, field)
 			case "protocol":
@@ -7431,6 +7831,10 @@ func (ec *executionContext) fieldContext_LoadBalancerPoolUpdatePayload_loadBalan
 				return ec.fieldContext_LoadBalancerPool_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancerPool_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerPool_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerPool_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancerPool_name(ctx, field)
 			case "protocol":
@@ -7577,6 +7981,88 @@ func (ec *executionContext) fieldContext_LoadBalancerPort_updatedAt(ctx context.
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LoadBalancerPort_deletedAt(ctx context.Context, field graphql.CollectedField, obj *generated.Port) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LoadBalancerPort_deletedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalOTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LoadBalancerPort_deletedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LoadBalancerPort",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LoadBalancerPort_deletedBy(ctx context.Context, field graphql.CollectedField, obj *generated.Port) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LoadBalancerPort_deletedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LoadBalancerPort_deletedBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LoadBalancerPort",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -7842,6 +8328,10 @@ func (ec *executionContext) fieldContext_LoadBalancerPort_pools(ctx context.Cont
 				return ec.fieldContext_LoadBalancerPool_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancerPool_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerPool_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerPool_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancerPool_name(ctx, field)
 			case "protocol":
@@ -8121,6 +8611,10 @@ func (ec *executionContext) fieldContext_LoadBalancerPortCreatePayload_loadBalan
 				return ec.fieldContext_LoadBalancerPort_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerPort_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerPort_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerPort_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerPort_createdBy(ctx, field)
 			case "updatedBy":
@@ -8228,6 +8722,10 @@ func (ec *executionContext) fieldContext_LoadBalancerPortEdge_node(ctx context.C
 				return ec.fieldContext_LoadBalancerPort_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerPort_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerPort_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerPort_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerPort_createdBy(ctx, field)
 			case "updatedBy":
@@ -8338,6 +8836,10 @@ func (ec *executionContext) fieldContext_LoadBalancerPortUpdatePayload_loadBalan
 				return ec.fieldContext_LoadBalancerPort_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerPort_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerPort_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerPort_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerPort_createdBy(ctx, field)
 			case "updatedBy":
@@ -8486,6 +8988,88 @@ func (ec *executionContext) fieldContext_LoadBalancerProvider_updatedAt(ctx cont
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LoadBalancerProvider_deletedAt(ctx context.Context, field graphql.CollectedField, obj *generated.Provider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LoadBalancerProvider_deletedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalOTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LoadBalancerProvider_deletedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LoadBalancerProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _LoadBalancerProvider_deletedBy(ctx context.Context, field graphql.CollectedField, obj *generated.Provider) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_LoadBalancerProvider_deletedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DeletedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_LoadBalancerProvider_deletedBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "LoadBalancerProvider",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -8924,6 +9508,10 @@ func (ec *executionContext) fieldContext_LoadBalancerProviderCreatePayload_loadB
 				return ec.fieldContext_LoadBalancerProvider_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerProvider_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerProvider_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerProvider_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerProvider_createdBy(ctx, field)
 			case "updatedBy":
@@ -9027,6 +9615,10 @@ func (ec *executionContext) fieldContext_LoadBalancerProviderEdge_node(ctx conte
 				return ec.fieldContext_LoadBalancerProvider_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerProvider_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerProvider_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerProvider_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerProvider_createdBy(ctx, field)
 			case "updatedBy":
@@ -9133,6 +9725,10 @@ func (ec *executionContext) fieldContext_LoadBalancerProviderUpdatePayload_loadB
 				return ec.fieldContext_LoadBalancerProvider_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerProvider_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerProvider_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerProvider_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerProvider_createdBy(ctx, field)
 			case "updatedBy":
@@ -10575,6 +11171,10 @@ func (ec *executionContext) fieldContext_Query_loadBalancerPool(ctx context.Cont
 				return ec.fieldContext_LoadBalancerPool_createdBy(ctx, field)
 			case "updatedBy":
 				return ec.fieldContext_LoadBalancerPool_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerPool_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerPool_deletedBy(ctx, field)
 			case "name":
 				return ec.fieldContext_LoadBalancerPool_name(ctx, field)
 			case "protocol":
@@ -10650,6 +11250,10 @@ func (ec *executionContext) fieldContext_Query_loadBalancerProvider(ctx context.
 				return ec.fieldContext_LoadBalancerProvider_createdAt(ctx, field)
 			case "updatedAt":
 				return ec.fieldContext_LoadBalancerProvider_updatedAt(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancerProvider_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancerProvider_deletedBy(ctx, field)
 			case "createdBy":
 				return ec.fieldContext_LoadBalancerProvider_createdBy(ctx, field)
 			case "updatedBy":
@@ -13346,7 +13950,7 @@ func (ec *executionContext) unmarshalInputLoadBalancerOriginWhereInput(ctx conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "createdAt", "createdAtNEQ", "createdAtIn", "createdAtNotIn", "createdAtGT", "createdAtGTE", "createdAtLT", "createdAtLTE", "updatedAt", "updatedAtNEQ", "updatedAtIn", "updatedAtNotIn", "updatedAtGT", "updatedAtGTE", "updatedAtLT", "updatedAtLTE", "createdBy", "createdByNEQ", "createdByIn", "createdByNotIn", "createdByGT", "createdByGTE", "createdByLT", "createdByLTE", "createdByContains", "createdByHasPrefix", "createdByHasSuffix", "createdByIsNil", "createdByNotNil", "createdByEqualFold", "createdByContainsFold", "updatedBy", "updatedByNEQ", "updatedByIn", "updatedByNotIn", "updatedByGT", "updatedByGTE", "updatedByLT", "updatedByLTE", "updatedByContains", "updatedByHasPrefix", "updatedByHasSuffix", "updatedByIsNil", "updatedByNotNil", "updatedByEqualFold", "updatedByContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "weight", "weightNEQ", "weightIn", "weightNotIn", "weightGT", "weightGTE", "weightLT", "weightLTE", "target", "targetNEQ", "targetIn", "targetNotIn", "targetGT", "targetGTE", "targetLT", "targetLTE", "targetContains", "targetHasPrefix", "targetHasSuffix", "targetEqualFold", "targetContainsFold", "portNumber", "portNumberNEQ", "portNumberIn", "portNumberNotIn", "portNumberGT", "portNumberGTE", "portNumberLT", "portNumberLTE", "active", "activeNEQ", "hasPool", "hasPoolWith"}
+	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "createdAt", "createdAtNEQ", "createdAtIn", "createdAtNotIn", "createdAtGT", "createdAtGTE", "createdAtLT", "createdAtLTE", "updatedAt", "updatedAtNEQ", "updatedAtIn", "updatedAtNotIn", "updatedAtGT", "updatedAtGTE", "updatedAtLT", "updatedAtLTE", "deletedAt", "deletedAtNEQ", "deletedAtIn", "deletedAtNotIn", "deletedAtGT", "deletedAtGTE", "deletedAtLT", "deletedAtLTE", "deletedAtIsNil", "deletedAtNotNil", "deletedBy", "deletedByNEQ", "deletedByIn", "deletedByNotIn", "deletedByGT", "deletedByGTE", "deletedByLT", "deletedByLTE", "deletedByContains", "deletedByHasPrefix", "deletedByHasSuffix", "deletedByIsNil", "deletedByNotNil", "deletedByEqualFold", "deletedByContainsFold", "createdBy", "createdByNEQ", "createdByIn", "createdByNotIn", "createdByGT", "createdByGTE", "createdByLT", "createdByLTE", "createdByContains", "createdByHasPrefix", "createdByHasSuffix", "createdByIsNil", "createdByNotNil", "createdByEqualFold", "createdByContainsFold", "updatedBy", "updatedByNEQ", "updatedByIn", "updatedByNotIn", "updatedByGT", "updatedByGTE", "updatedByLT", "updatedByLTE", "updatedByContains", "updatedByHasPrefix", "updatedByHasSuffix", "updatedByIsNil", "updatedByNotNil", "updatedByEqualFold", "updatedByContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "weight", "weightNEQ", "weightIn", "weightNotIn", "weightGT", "weightGTE", "weightLT", "weightLTE", "target", "targetNEQ", "targetIn", "targetNotIn", "targetGT", "targetGTE", "targetLT", "targetLTE", "targetContains", "targetHasPrefix", "targetHasSuffix", "targetEqualFold", "targetContainsFold", "portNumber", "portNumberNEQ", "portNumberIn", "portNumberNotIn", "portNumberGT", "portNumberGTE", "portNumberLT", "portNumberLTE", "active", "activeNEQ", "hasPool", "hasPoolWith"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -13596,6 +14200,231 @@ func (ec *executionContext) unmarshalInputLoadBalancerOriginWhereInput(ctx conte
 				return it, err
 			}
 			it.UpdatedAtLTE = data
+		case "deletedAt":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAt"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAt = data
+		case "deletedAtNEQ":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNEQ"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNEQ = data
+		case "deletedAtIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtIn"))
+			data, err := ec.unmarshalOTime2ᚕtimeᚐTimeᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtIn = data
+		case "deletedAtNotIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNotIn"))
+			data, err := ec.unmarshalOTime2ᚕtimeᚐTimeᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNotIn = data
+		case "deletedAtGT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtGT"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtGT = data
+		case "deletedAtGTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtGTE"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtGTE = data
+		case "deletedAtLT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtLT"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtLT = data
+		case "deletedAtLTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtLTE"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtLTE = data
+		case "deletedAtIsNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtIsNil = data
+		case "deletedAtNotNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNotNil = data
+		case "deletedBy":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedBy"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedBy = data
+		case "deletedByNEQ":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNEQ"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNEQ = data
+		case "deletedByIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByIn = data
+		case "deletedByNotIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNotIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNotIn = data
+		case "deletedByGT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByGT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByGT = data
+		case "deletedByGTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByGTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByGTE = data
+		case "deletedByLT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByLT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByLT = data
+		case "deletedByLTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByLTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByLTE = data
+		case "deletedByContains":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByContains"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByContains = data
+		case "deletedByHasPrefix":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByHasPrefix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByHasPrefix = data
+		case "deletedByHasSuffix":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByHasSuffix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByHasSuffix = data
+		case "deletedByIsNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByIsNil = data
+		case "deletedByNotNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNotNil = data
+		case "deletedByEqualFold":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByEqualFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByEqualFold = data
+		case "deletedByContainsFold":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByContainsFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByContainsFold = data
 		case "createdBy":
 			var err error
 
@@ -14335,7 +15164,7 @@ func (ec *executionContext) unmarshalInputLoadBalancerPoolWhereInput(ctx context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "createdAt", "createdAtNEQ", "createdAtIn", "createdAtNotIn", "createdAtGT", "createdAtGTE", "createdAtLT", "createdAtLTE", "updatedAt", "updatedAtNEQ", "updatedAtIn", "updatedAtNotIn", "updatedAtGT", "updatedAtGTE", "updatedAtLT", "updatedAtLTE", "createdBy", "createdByNEQ", "createdByIn", "createdByNotIn", "createdByGT", "createdByGTE", "createdByLT", "createdByLTE", "createdByContains", "createdByHasPrefix", "createdByHasSuffix", "createdByIsNil", "createdByNotNil", "createdByEqualFold", "createdByContainsFold", "updatedBy", "updatedByNEQ", "updatedByIn", "updatedByNotIn", "updatedByGT", "updatedByGTE", "updatedByLT", "updatedByLTE", "updatedByContains", "updatedByHasPrefix", "updatedByHasSuffix", "updatedByIsNil", "updatedByNotNil", "updatedByEqualFold", "updatedByContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "protocol", "protocolNEQ", "protocolIn", "protocolNotIn", "hasPorts", "hasPortsWith", "hasOrigins", "hasOriginsWith"}
+	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "createdAt", "createdAtNEQ", "createdAtIn", "createdAtNotIn", "createdAtGT", "createdAtGTE", "createdAtLT", "createdAtLTE", "updatedAt", "updatedAtNEQ", "updatedAtIn", "updatedAtNotIn", "updatedAtGT", "updatedAtGTE", "updatedAtLT", "updatedAtLTE", "createdBy", "createdByNEQ", "createdByIn", "createdByNotIn", "createdByGT", "createdByGTE", "createdByLT", "createdByLTE", "createdByContains", "createdByHasPrefix", "createdByHasSuffix", "createdByIsNil", "createdByNotNil", "createdByEqualFold", "createdByContainsFold", "updatedBy", "updatedByNEQ", "updatedByIn", "updatedByNotIn", "updatedByGT", "updatedByGTE", "updatedByLT", "updatedByLTE", "updatedByContains", "updatedByHasPrefix", "updatedByHasSuffix", "updatedByIsNil", "updatedByNotNil", "updatedByEqualFold", "updatedByContainsFold", "deletedAt", "deletedAtNEQ", "deletedAtIn", "deletedAtNotIn", "deletedAtGT", "deletedAtGTE", "deletedAtLT", "deletedAtLTE", "deletedAtIsNil", "deletedAtNotNil", "deletedBy", "deletedByNEQ", "deletedByIn", "deletedByNotIn", "deletedByGT", "deletedByGTE", "deletedByLT", "deletedByLTE", "deletedByContains", "deletedByHasPrefix", "deletedByHasSuffix", "deletedByIsNil", "deletedByNotNil", "deletedByEqualFold", "deletedByContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "protocol", "protocolNEQ", "protocolIn", "protocolNotIn", "hasPorts", "hasPortsWith", "hasOrigins", "hasOriginsWith"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -14855,6 +15684,231 @@ func (ec *executionContext) unmarshalInputLoadBalancerPoolWhereInput(ctx context
 				return it, err
 			}
 			it.UpdatedByContainsFold = data
+		case "deletedAt":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAt"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAt = data
+		case "deletedAtNEQ":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNEQ"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNEQ = data
+		case "deletedAtIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtIn"))
+			data, err := ec.unmarshalOTime2ᚕtimeᚐTimeᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtIn = data
+		case "deletedAtNotIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNotIn"))
+			data, err := ec.unmarshalOTime2ᚕtimeᚐTimeᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNotIn = data
+		case "deletedAtGT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtGT"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtGT = data
+		case "deletedAtGTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtGTE"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtGTE = data
+		case "deletedAtLT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtLT"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtLT = data
+		case "deletedAtLTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtLTE"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtLTE = data
+		case "deletedAtIsNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtIsNil = data
+		case "deletedAtNotNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNotNil = data
+		case "deletedBy":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedBy"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedBy = data
+		case "deletedByNEQ":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNEQ"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNEQ = data
+		case "deletedByIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByIn = data
+		case "deletedByNotIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNotIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNotIn = data
+		case "deletedByGT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByGT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByGT = data
+		case "deletedByGTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByGTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByGTE = data
+		case "deletedByLT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByLT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByLT = data
+		case "deletedByLTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByLTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByLTE = data
+		case "deletedByContains":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByContains"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByContains = data
+		case "deletedByHasPrefix":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByHasPrefix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByHasPrefix = data
+		case "deletedByHasSuffix":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByHasSuffix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByHasSuffix = data
+		case "deletedByIsNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByIsNil = data
+		case "deletedByNotNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNotNil = data
+		case "deletedByEqualFold":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByEqualFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByEqualFold = data
+		case "deletedByContainsFold":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByContainsFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByContainsFold = data
 		case "name":
 			var err error
 
@@ -15099,7 +16153,7 @@ func (ec *executionContext) unmarshalInputLoadBalancerPortWhereInput(ctx context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "createdAt", "createdAtNEQ", "createdAtIn", "createdAtNotIn", "createdAtGT", "createdAtGTE", "createdAtLT", "createdAtLTE", "updatedAt", "updatedAtNEQ", "updatedAtIn", "updatedAtNotIn", "updatedAtGT", "updatedAtGTE", "updatedAtLT", "updatedAtLTE", "createdBy", "createdByNEQ", "createdByIn", "createdByNotIn", "createdByGT", "createdByGTE", "createdByLT", "createdByLTE", "createdByContains", "createdByHasPrefix", "createdByHasSuffix", "createdByIsNil", "createdByNotNil", "createdByEqualFold", "createdByContainsFold", "updatedBy", "updatedByNEQ", "updatedByIn", "updatedByNotIn", "updatedByGT", "updatedByGTE", "updatedByLT", "updatedByLTE", "updatedByContains", "updatedByHasPrefix", "updatedByHasSuffix", "updatedByIsNil", "updatedByNotNil", "updatedByEqualFold", "updatedByContainsFold", "number", "numberNEQ", "numberIn", "numberNotIn", "numberGT", "numberGTE", "numberLT", "numberLTE", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "hasPools", "hasPoolsWith", "hasLoadBalancer", "hasLoadBalancerWith"}
+	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "createdAt", "createdAtNEQ", "createdAtIn", "createdAtNotIn", "createdAtGT", "createdAtGTE", "createdAtLT", "createdAtLTE", "updatedAt", "updatedAtNEQ", "updatedAtIn", "updatedAtNotIn", "updatedAtGT", "updatedAtGTE", "updatedAtLT", "updatedAtLTE", "deletedAt", "deletedAtNEQ", "deletedAtIn", "deletedAtNotIn", "deletedAtGT", "deletedAtGTE", "deletedAtLT", "deletedAtLTE", "deletedAtIsNil", "deletedAtNotNil", "deletedBy", "deletedByNEQ", "deletedByIn", "deletedByNotIn", "deletedByGT", "deletedByGTE", "deletedByLT", "deletedByLTE", "deletedByContains", "deletedByHasPrefix", "deletedByHasSuffix", "deletedByIsNil", "deletedByNotNil", "deletedByEqualFold", "deletedByContainsFold", "createdBy", "createdByNEQ", "createdByIn", "createdByNotIn", "createdByGT", "createdByGTE", "createdByLT", "createdByLTE", "createdByContains", "createdByHasPrefix", "createdByHasSuffix", "createdByIsNil", "createdByNotNil", "createdByEqualFold", "createdByContainsFold", "updatedBy", "updatedByNEQ", "updatedByIn", "updatedByNotIn", "updatedByGT", "updatedByGTE", "updatedByLT", "updatedByLTE", "updatedByContains", "updatedByHasPrefix", "updatedByHasSuffix", "updatedByIsNil", "updatedByNotNil", "updatedByEqualFold", "updatedByContainsFold", "number", "numberNEQ", "numberIn", "numberNotIn", "numberGT", "numberGTE", "numberLT", "numberLTE", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "hasPools", "hasPoolsWith", "hasLoadBalancer", "hasLoadBalancerWith"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -15349,6 +16403,231 @@ func (ec *executionContext) unmarshalInputLoadBalancerPortWhereInput(ctx context
 				return it, err
 			}
 			it.UpdatedAtLTE = data
+		case "deletedAt":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAt"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAt = data
+		case "deletedAtNEQ":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNEQ"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNEQ = data
+		case "deletedAtIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtIn"))
+			data, err := ec.unmarshalOTime2ᚕtimeᚐTimeᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtIn = data
+		case "deletedAtNotIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNotIn"))
+			data, err := ec.unmarshalOTime2ᚕtimeᚐTimeᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNotIn = data
+		case "deletedAtGT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtGT"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtGT = data
+		case "deletedAtGTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtGTE"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtGTE = data
+		case "deletedAtLT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtLT"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtLT = data
+		case "deletedAtLTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtLTE"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtLTE = data
+		case "deletedAtIsNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtIsNil = data
+		case "deletedAtNotNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNotNil = data
+		case "deletedBy":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedBy"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedBy = data
+		case "deletedByNEQ":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNEQ"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNEQ = data
+		case "deletedByIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByIn = data
+		case "deletedByNotIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNotIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNotIn = data
+		case "deletedByGT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByGT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByGT = data
+		case "deletedByGTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByGTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByGTE = data
+		case "deletedByLT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByLT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByLT = data
+		case "deletedByLTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByLTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByLTE = data
+		case "deletedByContains":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByContains"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByContains = data
+		case "deletedByHasPrefix":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByHasPrefix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByHasPrefix = data
+		case "deletedByHasSuffix":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByHasSuffix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByHasSuffix = data
+		case "deletedByIsNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByIsNil = data
+		case "deletedByNotNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNotNil = data
+		case "deletedByEqualFold":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByEqualFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByEqualFold = data
+		case "deletedByContainsFold":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByContainsFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByContainsFold = data
 		case "createdBy":
 			var err error
 
@@ -15899,7 +17178,7 @@ func (ec *executionContext) unmarshalInputLoadBalancerProviderWhereInput(ctx con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "createdAt", "createdAtNEQ", "createdAtIn", "createdAtNotIn", "createdAtGT", "createdAtGTE", "createdAtLT", "createdAtLTE", "updatedAt", "updatedAtNEQ", "updatedAtIn", "updatedAtNotIn", "updatedAtGT", "updatedAtGTE", "updatedAtLT", "updatedAtLTE", "createdBy", "createdByNEQ", "createdByIn", "createdByNotIn", "createdByGT", "createdByGTE", "createdByLT", "createdByLTE", "createdByContains", "createdByHasPrefix", "createdByHasSuffix", "createdByIsNil", "createdByNotNil", "createdByEqualFold", "createdByContainsFold", "updatedBy", "updatedByNEQ", "updatedByIn", "updatedByNotIn", "updatedByGT", "updatedByGTE", "updatedByLT", "updatedByLTE", "updatedByContains", "updatedByHasPrefix", "updatedByHasSuffix", "updatedByIsNil", "updatedByNotNil", "updatedByEqualFold", "updatedByContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "hasLoadBalancers", "hasLoadBalancersWith"}
+	fieldsInOrder := [...]string{"not", "and", "or", "id", "idNEQ", "idIn", "idNotIn", "idGT", "idGTE", "idLT", "idLTE", "createdAt", "createdAtNEQ", "createdAtIn", "createdAtNotIn", "createdAtGT", "createdAtGTE", "createdAtLT", "createdAtLTE", "updatedAt", "updatedAtNEQ", "updatedAtIn", "updatedAtNotIn", "updatedAtGT", "updatedAtGTE", "updatedAtLT", "updatedAtLTE", "deletedAt", "deletedAtNEQ", "deletedAtIn", "deletedAtNotIn", "deletedAtGT", "deletedAtGTE", "deletedAtLT", "deletedAtLTE", "deletedAtIsNil", "deletedAtNotNil", "deletedBy", "deletedByNEQ", "deletedByIn", "deletedByNotIn", "deletedByGT", "deletedByGTE", "deletedByLT", "deletedByLTE", "deletedByContains", "deletedByHasPrefix", "deletedByHasSuffix", "deletedByIsNil", "deletedByNotNil", "deletedByEqualFold", "deletedByContainsFold", "createdBy", "createdByNEQ", "createdByIn", "createdByNotIn", "createdByGT", "createdByGTE", "createdByLT", "createdByLTE", "createdByContains", "createdByHasPrefix", "createdByHasSuffix", "createdByIsNil", "createdByNotNil", "createdByEqualFold", "createdByContainsFold", "updatedBy", "updatedByNEQ", "updatedByIn", "updatedByNotIn", "updatedByGT", "updatedByGTE", "updatedByLT", "updatedByLTE", "updatedByContains", "updatedByHasPrefix", "updatedByHasSuffix", "updatedByIsNil", "updatedByNotNil", "updatedByEqualFold", "updatedByContainsFold", "name", "nameNEQ", "nameIn", "nameNotIn", "nameGT", "nameGTE", "nameLT", "nameLTE", "nameContains", "nameHasPrefix", "nameHasSuffix", "nameEqualFold", "nameContainsFold", "hasLoadBalancers", "hasLoadBalancersWith"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -16149,6 +17428,231 @@ func (ec *executionContext) unmarshalInputLoadBalancerProviderWhereInput(ctx con
 				return it, err
 			}
 			it.UpdatedAtLTE = data
+		case "deletedAt":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAt"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAt = data
+		case "deletedAtNEQ":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNEQ"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNEQ = data
+		case "deletedAtIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtIn"))
+			data, err := ec.unmarshalOTime2ᚕtimeᚐTimeᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtIn = data
+		case "deletedAtNotIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNotIn"))
+			data, err := ec.unmarshalOTime2ᚕtimeᚐTimeᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNotIn = data
+		case "deletedAtGT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtGT"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtGT = data
+		case "deletedAtGTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtGTE"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtGTE = data
+		case "deletedAtLT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtLT"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtLT = data
+		case "deletedAtLTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtLTE"))
+			data, err := ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtLTE = data
+		case "deletedAtIsNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtIsNil = data
+		case "deletedAtNotNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedAtNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedAtNotNil = data
+		case "deletedBy":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedBy"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedBy = data
+		case "deletedByNEQ":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNEQ"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNEQ = data
+		case "deletedByIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByIn = data
+		case "deletedByNotIn":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNotIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNotIn = data
+		case "deletedByGT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByGT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByGT = data
+		case "deletedByGTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByGTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByGTE = data
+		case "deletedByLT":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByLT"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByLT = data
+		case "deletedByLTE":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByLTE"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByLTE = data
+		case "deletedByContains":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByContains"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByContains = data
+		case "deletedByHasPrefix":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByHasPrefix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByHasPrefix = data
+		case "deletedByHasSuffix":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByHasSuffix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByHasSuffix = data
+		case "deletedByIsNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByIsNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByIsNil = data
+		case "deletedByNotNil":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByNotNil"))
+			data, err := ec.unmarshalOBoolean2bool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByNotNil = data
+		case "deletedByEqualFold":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByEqualFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByEqualFold = data
+		case "deletedByContainsFold":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("deletedByContainsFold"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DeletedByContainsFold = data
 		case "createdBy":
 			var err error
 
@@ -18503,6 +20007,10 @@ func (ec *executionContext) _LoadBalancerOrigin(ctx context.Context, sel ast.Sel
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "deletedAt":
+			out.Values[i] = ec._LoadBalancerOrigin_deletedAt(ctx, field, obj)
+		case "deletedBy":
+			out.Values[i] = ec._LoadBalancerOrigin_deletedBy(ctx, field, obj)
 		case "createdBy":
 			out.Values[i] = ec._LoadBalancerOrigin_createdBy(ctx, field, obj)
 		case "updatedBy":
@@ -18830,6 +20338,10 @@ func (ec *executionContext) _LoadBalancerPool(ctx context.Context, sel ast.Selec
 			out.Values[i] = ec._LoadBalancerPool_createdBy(ctx, field, obj)
 		case "updatedBy":
 			out.Values[i] = ec._LoadBalancerPool_updatedBy(ctx, field, obj)
+		case "deletedAt":
+			out.Values[i] = ec._LoadBalancerPool_deletedAt(ctx, field, obj)
+		case "deletedBy":
+			out.Values[i] = ec._LoadBalancerPool_deletedBy(ctx, field, obj)
 		case "name":
 			out.Values[i] = ec._LoadBalancerPool_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -19200,6 +20712,10 @@ func (ec *executionContext) _LoadBalancerPort(ctx context.Context, sel ast.Selec
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "deletedAt":
+			out.Values[i] = ec._LoadBalancerPort_deletedAt(ctx, field, obj)
+		case "deletedBy":
+			out.Values[i] = ec._LoadBalancerPort_deletedBy(ctx, field, obj)
 		case "createdBy":
 			out.Values[i] = ec._LoadBalancerPort_createdBy(ctx, field, obj)
 		case "updatedBy":
@@ -19541,6 +21057,10 @@ func (ec *executionContext) _LoadBalancerProvider(ctx context.Context, sel ast.S
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "deletedAt":
+			out.Values[i] = ec._LoadBalancerProvider_deletedAt(ctx, field, obj)
+		case "deletedBy":
+			out.Values[i] = ec._LoadBalancerProvider_deletedBy(ctx, field, obj)
 		case "createdBy":
 			out.Values[i] = ec._LoadBalancerProvider_createdBy(ctx, field, obj)
 		case "updatedBy":

--- a/internal/graphapi/gen_server.go
+++ b/internal/graphapi/gen_server.go
@@ -289,6 +289,7 @@ type ComplexityRoot struct {
 
 	Query struct {
 		LoadBalancer         func(childComplexity int, id gidx.PrefixedID) int
+		LoadBalancerHistory  func(childComplexity int, id gidx.PrefixedID) int
 		LoadBalancerPool     func(childComplexity int, id gidx.PrefixedID) int
 		LoadBalancerPools    func(childComplexity int, after *entgql.Cursor[gidx.PrefixedID], first *int, before *entgql.Cursor[gidx.PrefixedID], last *int, orderBy *generated.LoadBalancerPoolOrder, where *generated.LoadBalancerPoolWhereInput) int
 		LoadBalancerProvider func(childComplexity int, id gidx.PrefixedID) int
@@ -350,6 +351,7 @@ type MutationResolver interface {
 type QueryResolver interface {
 	LoadBalancerPools(ctx context.Context, after *entgql.Cursor[gidx.PrefixedID], first *int, before *entgql.Cursor[gidx.PrefixedID], last *int, orderBy *generated.LoadBalancerPoolOrder, where *generated.LoadBalancerPoolWhereInput) (*generated.LoadBalancerPoolConnection, error)
 	LoadBalancer(ctx context.Context, id gidx.PrefixedID) (*generated.LoadBalancer, error)
+	LoadBalancerHistory(ctx context.Context, id gidx.PrefixedID) (*generated.LoadBalancer, error)
 	LoadBalancerPool(ctx context.Context, id gidx.PrefixedID) (*generated.Pool, error)
 	LoadBalancerProvider(ctx context.Context, id gidx.PrefixedID) (*generated.Provider, error)
 }
@@ -1418,6 +1420,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.LoadBalancer(childComplexity, args["id"].(gidx.PrefixedID)), true
+
+	case "Query.loadBalancerHistory":
+		if e.complexity.Query.LoadBalancerHistory == nil {
+			break
+		}
+
+		args, err := ec.field_Query_loadBalancerHistory_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.LoadBalancerHistory(childComplexity, args["id"].(gidx.PrefixedID)), true
 
 	case "Query.loadBalancerPool":
 		if e.complexity.Query.LoadBalancerPool == nil {
@@ -2749,6 +2763,15 @@ input UpdateLoadBalancerProviderInput {
     """
     id: ID!
   ): LoadBalancer!
+    """
+  Lookup a load balancer by ID.
+  """
+  loadBalancerHistory(
+    """
+    The load balancer ID.
+    """
+    id: ID!
+  ): LoadBalancer!
 }
 
 extend type Mutation {
@@ -3913,6 +3936,21 @@ func (ec *executionContext) field_Query__entities_args(ctx context.Context, rawA
 		}
 	}
 	args["representations"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_loadBalancerHistory_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 gidx.PrefixedID
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNID2goᚗinfratographerᚗcomᚋxᚋgidxᚐPrefixedID(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
 	return args, nil
 }
 
@@ -11116,6 +11154,87 @@ func (ec *executionContext) fieldContext_Query_loadBalancer(ctx context.Context,
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_loadBalancer_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_loadBalancerHistory(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_loadBalancerHistory(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().LoadBalancerHistory(rctx, fc.Args["id"].(gidx.PrefixedID))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*generated.LoadBalancer)
+	fc.Result = res
+	return ec.marshalNLoadBalancer2ᚖgoᚗinfratographerᚗcomᚋloadᚑbalancerᚑapiᚋinternalᚋentᚋgeneratedᚐLoadBalancer(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_loadBalancerHistory(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_LoadBalancer_id(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_LoadBalancer_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_LoadBalancer_updatedAt(ctx, field)
+			case "createdBy":
+				return ec.fieldContext_LoadBalancer_createdBy(ctx, field)
+			case "updatedBy":
+				return ec.fieldContext_LoadBalancer_updatedBy(ctx, field)
+			case "deletedAt":
+				return ec.fieldContext_LoadBalancer_deletedAt(ctx, field)
+			case "deletedBy":
+				return ec.fieldContext_LoadBalancer_deletedBy(ctx, field)
+			case "name":
+				return ec.fieldContext_LoadBalancer_name(ctx, field)
+			case "ports":
+				return ec.fieldContext_LoadBalancer_ports(ctx, field)
+			case "loadBalancerProvider":
+				return ec.fieldContext_LoadBalancer_loadBalancerProvider(ctx, field)
+			case "location":
+				return ec.fieldContext_LoadBalancer_location(ctx, field)
+			case "owner":
+				return ec.fieldContext_LoadBalancer_owner(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type LoadBalancer", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_loadBalancerHistory_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -21729,6 +21848,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_loadBalancer(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "loadBalancerHistory":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_loadBalancerHistory(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/graphapi/loadbalancer.resolvers.go
+++ b/internal/graphapi/loadbalancer.resolvers.go
@@ -209,14 +209,8 @@ func (r *queryResolver) LoadBalancer(ctx context.Context, id gidx.PrefixedID) (*
 	return lb, nil
 }
 
-// !!! WARNING !!!
-// The code below was going to be deleted when updating resolvers. It has been copied here so you have
-// one last chance to move it out of harms way if you want. There are two reasons this happens:
-//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
-//     it when you're done.
-//   - You have helper methods in this file. Move them out to keep these resolver files clean.
+// LoadBalancerHistory is the resolver for the loadBalancerHistory field.
 func (r *queryResolver) LoadBalancerHistory(ctx context.Context, id gidx.PrefixedID) (*generated.LoadBalancer, error) {
-
 	ctx = softdelete.SkipSoftDelete(ctx)
 
 	logger := r.logger.With("loadbalancerID", id.String())

--- a/internal/graphapi/loadbalancer.resolvers.go
+++ b/internal/graphapi/loadbalancer.resolvers.go
@@ -14,6 +14,7 @@ import (
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/port"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/predicate"
 	_ "go.infratographer.com/load-balancer-api/internal/ent/generated/runtime"
+	"go.infratographer.com/load-balancer-api/internal/ent/schema/softdelete"
 	"go.infratographer.com/load-balancer-api/pkg/metadata"
 	"go.infratographer.com/permissions-api/pkg/permissions"
 	"go.infratographer.com/x/events"
@@ -202,6 +203,40 @@ func (r *queryResolver) LoadBalancer(ctx context.Context, id gidx.PrefixedID) (*
 	}
 
 	if err := permissions.CheckAccess(ctx, lb.OwnerID, actionLoadBalancerGet); err != nil {
+		return nil, err
+	}
+
+	return lb, nil
+}
+
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//     it when you're done.
+//   - You have helper methods in this file. Move them out to keep these resolver files clean.
+func (r *queryResolver) LoadBalancerHistory(ctx context.Context, id gidx.PrefixedID) (*generated.LoadBalancer, error) {
+
+	ctx = softdelete.SkipSoftDelete(ctx)
+
+	logger := r.logger.With("loadbalancerID", id.String())
+
+	// check gidx format
+	if _, err := gidx.Parse(id.String()); err != nil {
+		return nil, err
+	}
+
+	lb, err := r.client.LoadBalancer.Get(ctx, id)
+	if err != nil {
+		if generated.IsNotFound(err) {
+			return nil, err
+		}
+
+		logger.Errorw("failed to get loadbalancer", "error", err)
+		return nil, ErrInternalServerError
+	}
+
+	if err := permissions.CheckAccess(ctx, lb.OwnerID, actionLoadBalancerGetHistory); err != nil {
 		return nil, err
 	}
 

--- a/internal/graphapi/permissions.go
+++ b/internal/graphapi/permissions.go
@@ -1,18 +1,21 @@
 package graphapi
 
 const (
-	actionLoadBalancerCreate = "loadbalancer_create"
-	actionLoadBalancerUpdate = "loadbalancer_update"
-	actionLoadBalancerDelete = "loadbalancer_delete"
-	actionLoadBalancerGet    = "loadbalancer_get"
+	actionLoadBalancerCreate     = "loadbalancer_create"
+	actionLoadBalancerUpdate     = "loadbalancer_update"
+	actionLoadBalancerDelete     = "loadbalancer_delete"
+	actionLoadBalancerGet        = "loadbalancer_get"
+	actionLoadBalancerGetHistory = "loadbalancer_get_history"
 
-	actionLoadBalancerPoolCreate = "loadbalancerpool_create"
-	actionLoadBalancerPoolUpdate = "loadbalancerpool_update"
-	actionLoadBalancerPoolDelete = "loadbalancerpool_delete"
-	actionLoadBalancerPoolGet    = "loadbalancerpool_get"
+	actionLoadBalancerPoolCreate     = "loadbalancerpool_create"
+	actionLoadBalancerPoolUpdate     = "loadbalancerpool_update"
+	actionLoadBalancerPoolDelete     = "loadbalancerpool_delete"
+	actionLoadBalancerPoolGet        = "loadbalancerpool_get"
+	actionLoadBalancerPoolGetHistory = "loadbalancerpool_get_history"
 
-	actionLoadBalancerProviderCreate = "loadbalancerprovider_create"
-	actionLoadBalancerProviderUpdate = "loadbalancerprovider_update"
-	actionLoadBalancerProviderDelete = "loadbalancerprovider_delete"
-	actionLoadBalancerProviderGet    = "loadbalancerprovider_get"
+	actionLoadBalancerProviderCreate     = "loadbalancerprovider_create"
+	actionLoadBalancerProviderUpdate     = "loadbalancerprovider_update"
+	actionLoadBalancerProviderDelete     = "loadbalancerprovider_delete"
+	actionLoadBalancerProviderGet        = "loadbalancerprovider_get"
+	actionLoadBalancerProviderGetHistory = "loadbalancerprovider_get_history"
 )

--- a/internal/graphclient/gen_client.go
+++ b/internal/graphclient/gen_client.go
@@ -46,6 +46,7 @@ func NewClient(cli *http.Client, baseURL string, options ...client.HTTPRequestOp
 type Query struct {
 	LoadBalancerPools    LoadBalancerPoolConnection "json:\"loadBalancerPools\" graphql:\"loadBalancerPools\""
 	LoadBalancer         LoadBalancer               "json:\"loadBalancer\" graphql:\"loadBalancer\""
+	LoadBalancerHistory  LoadBalancer               "json:\"loadBalancerHistory\" graphql:\"loadBalancerHistory\""
 	LoadBalancerPool     LoadBalancerPool           "json:\"loadBalancerPool\" graphql:\"loadBalancerPool\""
 	LoadBalancerProvider LoadBalancerProvider       "json:\"loadBalancerProvider\" graphql:\"loadBalancerProvider\""
 	Entities             []Entity                   "json:\"_entities\" graphql:\"_entities\""

--- a/internal/graphclient/gen_models.go
+++ b/internal/graphclient/gen_models.go
@@ -90,6 +90,8 @@ type LoadBalancer struct {
 	UpdatedAt time.Time       `json:"updatedAt"`
 	CreatedBy *string         `json:"createdBy,omitempty"`
 	UpdatedBy *string         `json:"updatedBy,omitempty"`
+	DeletedAt *time.Time      `json:"deletedAt,omitempty"`
+	DeletedBy *string         `json:"deletedBy,omitempty"`
 	// The name of the load balancer.
 	Name  string                     `json:"name"`
 	Ports LoadBalancerPortConnection `json:"ports"`
@@ -873,6 +875,33 @@ type LoadBalancerWhereInput struct {
 	UpdatedByNotNil       *bool    `json:"updatedByNotNil,omitempty"`
 	UpdatedByEqualFold    *string  `json:"updatedByEqualFold,omitempty"`
 	UpdatedByContainsFold *string  `json:"updatedByContainsFold,omitempty"`
+	// deleted_at field predicates
+	DeletedAt       *time.Time   `json:"deletedAt,omitempty"`
+	DeletedAtNeq    *time.Time   `json:"deletedAtNEQ,omitempty"`
+	DeletedAtIn     []*time.Time `json:"deletedAtIn,omitempty"`
+	DeletedAtNotIn  []*time.Time `json:"deletedAtNotIn,omitempty"`
+	DeletedAtGt     *time.Time   `json:"deletedAtGT,omitempty"`
+	DeletedAtGte    *time.Time   `json:"deletedAtGTE,omitempty"`
+	DeletedAtLt     *time.Time   `json:"deletedAtLT,omitempty"`
+	DeletedAtLte    *time.Time   `json:"deletedAtLTE,omitempty"`
+	DeletedAtIsNil  *bool        `json:"deletedAtIsNil,omitempty"`
+	DeletedAtNotNil *bool        `json:"deletedAtNotNil,omitempty"`
+	// deleted_by field predicates
+	DeletedBy             *string  `json:"deletedBy,omitempty"`
+	DeletedByNeq          *string  `json:"deletedByNEQ,omitempty"`
+	DeletedByIn           []string `json:"deletedByIn,omitempty"`
+	DeletedByNotIn        []string `json:"deletedByNotIn,omitempty"`
+	DeletedByGt           *string  `json:"deletedByGT,omitempty"`
+	DeletedByGte          *string  `json:"deletedByGTE,omitempty"`
+	DeletedByLt           *string  `json:"deletedByLT,omitempty"`
+	DeletedByLte          *string  `json:"deletedByLTE,omitempty"`
+	DeletedByContains     *string  `json:"deletedByContains,omitempty"`
+	DeletedByHasPrefix    *string  `json:"deletedByHasPrefix,omitempty"`
+	DeletedByHasSuffix    *string  `json:"deletedByHasSuffix,omitempty"`
+	DeletedByIsNil        *bool    `json:"deletedByIsNil,omitempty"`
+	DeletedByNotNil       *bool    `json:"deletedByNotNil,omitempty"`
+	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
+	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
 	// name field predicates
 	Name             *string  `json:"name,omitempty"`
 	NameNeq          *string  `json:"nameNEQ,omitempty"`
@@ -985,6 +1014,8 @@ const (
 	LoadBalancerOrderFieldUpdatedAt LoadBalancerOrderField = "UPDATED_AT"
 	LoadBalancerOrderFieldCreatedBy LoadBalancerOrderField = "CREATED_BY"
 	LoadBalancerOrderFieldUpdatedBy LoadBalancerOrderField = "UPDATED_BY"
+	LoadBalancerOrderFieldDeletedAt LoadBalancerOrderField = "DELETED_AT"
+	LoadBalancerOrderFieldDeletedBy LoadBalancerOrderField = "DELETED_BY"
 	LoadBalancerOrderFieldName      LoadBalancerOrderField = "NAME"
 	LoadBalancerOrderFieldOwner     LoadBalancerOrderField = "OWNER"
 )
@@ -995,13 +1026,15 @@ var AllLoadBalancerOrderField = []LoadBalancerOrderField{
 	LoadBalancerOrderFieldUpdatedAt,
 	LoadBalancerOrderFieldCreatedBy,
 	LoadBalancerOrderFieldUpdatedBy,
+	LoadBalancerOrderFieldDeletedAt,
+	LoadBalancerOrderFieldDeletedBy,
 	LoadBalancerOrderFieldName,
 	LoadBalancerOrderFieldOwner,
 }
 
 func (e LoadBalancerOrderField) IsValid() bool {
 	switch e {
-	case LoadBalancerOrderFieldID, LoadBalancerOrderFieldCreatedAt, LoadBalancerOrderFieldUpdatedAt, LoadBalancerOrderFieldCreatedBy, LoadBalancerOrderFieldUpdatedBy, LoadBalancerOrderFieldName, LoadBalancerOrderFieldOwner:
+	case LoadBalancerOrderFieldID, LoadBalancerOrderFieldCreatedAt, LoadBalancerOrderFieldUpdatedAt, LoadBalancerOrderFieldCreatedBy, LoadBalancerOrderFieldUpdatedBy, LoadBalancerOrderFieldDeletedAt, LoadBalancerOrderFieldDeletedBy, LoadBalancerOrderFieldName, LoadBalancerOrderFieldOwner:
 		return true
 	}
 	return false

--- a/internal/graphclient/gen_models.go
+++ b/internal/graphclient/gen_models.go
@@ -156,6 +156,8 @@ type LoadBalancerOrigin struct {
 	ID         gidx.PrefixedID  `json:"id"`
 	CreatedAt  time.Time        `json:"createdAt"`
 	UpdatedAt  time.Time        `json:"updatedAt"`
+	DeletedAt  *time.Time       `json:"deletedAt,omitempty"`
+	DeletedBy  *string          `json:"deletedBy,omitempty"`
 	CreatedBy  *string          `json:"createdBy,omitempty"`
 	UpdatedBy  *string          `json:"updatedBy,omitempty"`
 	Name       string           `json:"name"`
@@ -251,6 +253,33 @@ type LoadBalancerOriginWhereInput struct {
 	UpdatedAtGte   *time.Time   `json:"updatedAtGTE,omitempty"`
 	UpdatedAtLt    *time.Time   `json:"updatedAtLT,omitempty"`
 	UpdatedAtLte   *time.Time   `json:"updatedAtLTE,omitempty"`
+	// deleted_at field predicates
+	DeletedAt       *time.Time   `json:"deletedAt,omitempty"`
+	DeletedAtNeq    *time.Time   `json:"deletedAtNEQ,omitempty"`
+	DeletedAtIn     []*time.Time `json:"deletedAtIn,omitempty"`
+	DeletedAtNotIn  []*time.Time `json:"deletedAtNotIn,omitempty"`
+	DeletedAtGt     *time.Time   `json:"deletedAtGT,omitempty"`
+	DeletedAtGte    *time.Time   `json:"deletedAtGTE,omitempty"`
+	DeletedAtLt     *time.Time   `json:"deletedAtLT,omitempty"`
+	DeletedAtLte    *time.Time   `json:"deletedAtLTE,omitempty"`
+	DeletedAtIsNil  *bool        `json:"deletedAtIsNil,omitempty"`
+	DeletedAtNotNil *bool        `json:"deletedAtNotNil,omitempty"`
+	// deleted_by field predicates
+	DeletedBy             *string  `json:"deletedBy,omitempty"`
+	DeletedByNeq          *string  `json:"deletedByNEQ,omitempty"`
+	DeletedByIn           []string `json:"deletedByIn,omitempty"`
+	DeletedByNotIn        []string `json:"deletedByNotIn,omitempty"`
+	DeletedByGt           *string  `json:"deletedByGT,omitempty"`
+	DeletedByGte          *string  `json:"deletedByGTE,omitempty"`
+	DeletedByLt           *string  `json:"deletedByLT,omitempty"`
+	DeletedByLte          *string  `json:"deletedByLTE,omitempty"`
+	DeletedByContains     *string  `json:"deletedByContains,omitempty"`
+	DeletedByHasPrefix    *string  `json:"deletedByHasPrefix,omitempty"`
+	DeletedByHasSuffix    *string  `json:"deletedByHasSuffix,omitempty"`
+	DeletedByIsNil        *bool    `json:"deletedByIsNil,omitempty"`
+	DeletedByNotNil       *bool    `json:"deletedByNotNil,omitempty"`
+	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
+	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
 	// created_by field predicates
 	CreatedBy             *string  `json:"createdBy,omitempty"`
 	CreatedByNeq          *string  `json:"createdByNEQ,omitempty"`
@@ -343,6 +372,8 @@ type LoadBalancerPool struct {
 	UpdatedAt time.Time                    `json:"updatedAt"`
 	CreatedBy *string                      `json:"createdBy,omitempty"`
 	UpdatedBy *string                      `json:"updatedBy,omitempty"`
+	DeletedAt *time.Time                   `json:"deletedAt,omitempty"`
+	DeletedBy *string                      `json:"deletedBy,omitempty"`
 	Name      string                       `json:"name"`
 	Protocol  LoadBalancerPoolProtocol     `json:"protocol"`
 	OwnerID   gidx.PrefixedID              `json:"ownerID"`
@@ -468,6 +499,33 @@ type LoadBalancerPoolWhereInput struct {
 	UpdatedByNotNil       *bool    `json:"updatedByNotNil,omitempty"`
 	UpdatedByEqualFold    *string  `json:"updatedByEqualFold,omitempty"`
 	UpdatedByContainsFold *string  `json:"updatedByContainsFold,omitempty"`
+	// deleted_at field predicates
+	DeletedAt       *time.Time   `json:"deletedAt,omitempty"`
+	DeletedAtNeq    *time.Time   `json:"deletedAtNEQ,omitempty"`
+	DeletedAtIn     []*time.Time `json:"deletedAtIn,omitempty"`
+	DeletedAtNotIn  []*time.Time `json:"deletedAtNotIn,omitempty"`
+	DeletedAtGt     *time.Time   `json:"deletedAtGT,omitempty"`
+	DeletedAtGte    *time.Time   `json:"deletedAtGTE,omitempty"`
+	DeletedAtLt     *time.Time   `json:"deletedAtLT,omitempty"`
+	DeletedAtLte    *time.Time   `json:"deletedAtLTE,omitempty"`
+	DeletedAtIsNil  *bool        `json:"deletedAtIsNil,omitempty"`
+	DeletedAtNotNil *bool        `json:"deletedAtNotNil,omitempty"`
+	// deleted_by field predicates
+	DeletedBy             *string  `json:"deletedBy,omitempty"`
+	DeletedByNeq          *string  `json:"deletedByNEQ,omitempty"`
+	DeletedByIn           []string `json:"deletedByIn,omitempty"`
+	DeletedByNotIn        []string `json:"deletedByNotIn,omitempty"`
+	DeletedByGt           *string  `json:"deletedByGT,omitempty"`
+	DeletedByGte          *string  `json:"deletedByGTE,omitempty"`
+	DeletedByLt           *string  `json:"deletedByLT,omitempty"`
+	DeletedByLte          *string  `json:"deletedByLTE,omitempty"`
+	DeletedByContains     *string  `json:"deletedByContains,omitempty"`
+	DeletedByHasPrefix    *string  `json:"deletedByHasPrefix,omitempty"`
+	DeletedByHasSuffix    *string  `json:"deletedByHasSuffix,omitempty"`
+	DeletedByIsNil        *bool    `json:"deletedByIsNil,omitempty"`
+	DeletedByNotNil       *bool    `json:"deletedByNotNil,omitempty"`
+	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
+	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
 	// name field predicates
 	Name             *string  `json:"name,omitempty"`
 	NameNeq          *string  `json:"nameNEQ,omitempty"`
@@ -499,6 +557,8 @@ type LoadBalancerPort struct {
 	ID             gidx.PrefixedID     `json:"id"`
 	CreatedAt      time.Time           `json:"createdAt"`
 	UpdatedAt      time.Time           `json:"updatedAt"`
+	DeletedAt      *time.Time          `json:"deletedAt,omitempty"`
+	DeletedBy      *string             `json:"deletedBy,omitempty"`
 	CreatedBy      *string             `json:"createdBy,omitempty"`
 	UpdatedBy      *string             `json:"updatedBy,omitempty"`
 	Number         int64               `json:"number"`
@@ -592,6 +652,33 @@ type LoadBalancerPortWhereInput struct {
 	UpdatedAtGte   *time.Time   `json:"updatedAtGTE,omitempty"`
 	UpdatedAtLt    *time.Time   `json:"updatedAtLT,omitempty"`
 	UpdatedAtLte   *time.Time   `json:"updatedAtLTE,omitempty"`
+	// deleted_at field predicates
+	DeletedAt       *time.Time   `json:"deletedAt,omitempty"`
+	DeletedAtNeq    *time.Time   `json:"deletedAtNEQ,omitempty"`
+	DeletedAtIn     []*time.Time `json:"deletedAtIn,omitempty"`
+	DeletedAtNotIn  []*time.Time `json:"deletedAtNotIn,omitempty"`
+	DeletedAtGt     *time.Time   `json:"deletedAtGT,omitempty"`
+	DeletedAtGte    *time.Time   `json:"deletedAtGTE,omitempty"`
+	DeletedAtLt     *time.Time   `json:"deletedAtLT,omitempty"`
+	DeletedAtLte    *time.Time   `json:"deletedAtLTE,omitempty"`
+	DeletedAtIsNil  *bool        `json:"deletedAtIsNil,omitempty"`
+	DeletedAtNotNil *bool        `json:"deletedAtNotNil,omitempty"`
+	// deleted_by field predicates
+	DeletedBy             *string  `json:"deletedBy,omitempty"`
+	DeletedByNeq          *string  `json:"deletedByNEQ,omitempty"`
+	DeletedByIn           []string `json:"deletedByIn,omitempty"`
+	DeletedByNotIn        []string `json:"deletedByNotIn,omitempty"`
+	DeletedByGt           *string  `json:"deletedByGT,omitempty"`
+	DeletedByGte          *string  `json:"deletedByGTE,omitempty"`
+	DeletedByLt           *string  `json:"deletedByLT,omitempty"`
+	DeletedByLte          *string  `json:"deletedByLTE,omitempty"`
+	DeletedByContains     *string  `json:"deletedByContains,omitempty"`
+	DeletedByHasPrefix    *string  `json:"deletedByHasPrefix,omitempty"`
+	DeletedByHasSuffix    *string  `json:"deletedByHasSuffix,omitempty"`
+	DeletedByIsNil        *bool    `json:"deletedByIsNil,omitempty"`
+	DeletedByNotNil       *bool    `json:"deletedByNotNil,omitempty"`
+	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
+	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
 	// created_by field predicates
 	CreatedBy             *string  `json:"createdBy,omitempty"`
 	CreatedByNeq          *string  `json:"createdByNEQ,omitempty"`
@@ -660,6 +747,8 @@ type LoadBalancerProvider struct {
 	ID        gidx.PrefixedID `json:"id"`
 	CreatedAt time.Time       `json:"createdAt"`
 	UpdatedAt time.Time       `json:"updatedAt"`
+	DeletedAt *time.Time      `json:"deletedAt,omitempty"`
+	DeletedBy *string         `json:"deletedBy,omitempty"`
 	CreatedBy *string         `json:"createdBy,omitempty"`
 	UpdatedBy *string         `json:"updatedBy,omitempty"`
 	// The name of the load balancer provider.
@@ -753,6 +842,33 @@ type LoadBalancerProviderWhereInput struct {
 	UpdatedAtGte   *time.Time   `json:"updatedAtGTE,omitempty"`
 	UpdatedAtLt    *time.Time   `json:"updatedAtLT,omitempty"`
 	UpdatedAtLte   *time.Time   `json:"updatedAtLTE,omitempty"`
+	// deleted_at field predicates
+	DeletedAt       *time.Time   `json:"deletedAt,omitempty"`
+	DeletedAtNeq    *time.Time   `json:"deletedAtNEQ,omitempty"`
+	DeletedAtIn     []*time.Time `json:"deletedAtIn,omitempty"`
+	DeletedAtNotIn  []*time.Time `json:"deletedAtNotIn,omitempty"`
+	DeletedAtGt     *time.Time   `json:"deletedAtGT,omitempty"`
+	DeletedAtGte    *time.Time   `json:"deletedAtGTE,omitempty"`
+	DeletedAtLt     *time.Time   `json:"deletedAtLT,omitempty"`
+	DeletedAtLte    *time.Time   `json:"deletedAtLTE,omitempty"`
+	DeletedAtIsNil  *bool        `json:"deletedAtIsNil,omitempty"`
+	DeletedAtNotNil *bool        `json:"deletedAtNotNil,omitempty"`
+	// deleted_by field predicates
+	DeletedBy             *string  `json:"deletedBy,omitempty"`
+	DeletedByNeq          *string  `json:"deletedByNEQ,omitempty"`
+	DeletedByIn           []string `json:"deletedByIn,omitempty"`
+	DeletedByNotIn        []string `json:"deletedByNotIn,omitempty"`
+	DeletedByGt           *string  `json:"deletedByGT,omitempty"`
+	DeletedByGte          *string  `json:"deletedByGTE,omitempty"`
+	DeletedByLt           *string  `json:"deletedByLT,omitempty"`
+	DeletedByLte          *string  `json:"deletedByLTE,omitempty"`
+	DeletedByContains     *string  `json:"deletedByContains,omitempty"`
+	DeletedByHasPrefix    *string  `json:"deletedByHasPrefix,omitempty"`
+	DeletedByHasSuffix    *string  `json:"deletedByHasSuffix,omitempty"`
+	DeletedByIsNil        *bool    `json:"deletedByIsNil,omitempty"`
+	DeletedByNotNil       *bool    `json:"deletedByNotNil,omitempty"`
+	DeletedByEqualFold    *string  `json:"deletedByEqualFold,omitempty"`
+	DeletedByContainsFold *string  `json:"deletedByContainsFold,omitempty"`
 	// created_by field predicates
 	CreatedBy             *string  `json:"createdBy,omitempty"`
 	CreatedByNeq          *string  `json:"createdByNEQ,omitempty"`
@@ -1067,6 +1183,8 @@ type LoadBalancerOriginOrderField string
 const (
 	LoadBalancerOriginOrderFieldCreatedAt LoadBalancerOriginOrderField = "CREATED_AT"
 	LoadBalancerOriginOrderFieldUpdatedAt LoadBalancerOriginOrderField = "UPDATED_AT"
+	LoadBalancerOriginOrderFieldDeletedAt LoadBalancerOriginOrderField = "DELETED_AT"
+	LoadBalancerOriginOrderFieldDeletedBy LoadBalancerOriginOrderField = "DELETED_BY"
 	LoadBalancerOriginOrderFieldCreatedBy LoadBalancerOriginOrderField = "CREATED_BY"
 	LoadBalancerOriginOrderFieldUpdatedBy LoadBalancerOriginOrderField = "UPDATED_BY"
 	LoadBalancerOriginOrderFieldName      LoadBalancerOriginOrderField = "name"
@@ -1079,6 +1197,8 @@ const (
 var AllLoadBalancerOriginOrderField = []LoadBalancerOriginOrderField{
 	LoadBalancerOriginOrderFieldCreatedAt,
 	LoadBalancerOriginOrderFieldUpdatedAt,
+	LoadBalancerOriginOrderFieldDeletedAt,
+	LoadBalancerOriginOrderFieldDeletedBy,
 	LoadBalancerOriginOrderFieldCreatedBy,
 	LoadBalancerOriginOrderFieldUpdatedBy,
 	LoadBalancerOriginOrderFieldName,
@@ -1090,7 +1210,7 @@ var AllLoadBalancerOriginOrderField = []LoadBalancerOriginOrderField{
 
 func (e LoadBalancerOriginOrderField) IsValid() bool {
 	switch e {
-	case LoadBalancerOriginOrderFieldCreatedAt, LoadBalancerOriginOrderFieldUpdatedAt, LoadBalancerOriginOrderFieldCreatedBy, LoadBalancerOriginOrderFieldUpdatedBy, LoadBalancerOriginOrderFieldName, LoadBalancerOriginOrderFieldWeight, LoadBalancerOriginOrderFieldTarget, LoadBalancerOriginOrderFieldNumber, LoadBalancerOriginOrderFieldActive:
+	case LoadBalancerOriginOrderFieldCreatedAt, LoadBalancerOriginOrderFieldUpdatedAt, LoadBalancerOriginOrderFieldDeletedAt, LoadBalancerOriginOrderFieldDeletedBy, LoadBalancerOriginOrderFieldCreatedBy, LoadBalancerOriginOrderFieldUpdatedBy, LoadBalancerOriginOrderFieldName, LoadBalancerOriginOrderFieldWeight, LoadBalancerOriginOrderFieldTarget, LoadBalancerOriginOrderFieldNumber, LoadBalancerOriginOrderFieldActive:
 		return true
 	}
 	return false
@@ -1125,6 +1245,8 @@ const (
 	LoadBalancerPoolOrderFieldUpdatedAt LoadBalancerPoolOrderField = "UPDATED_AT"
 	LoadBalancerPoolOrderFieldCreatedBy LoadBalancerPoolOrderField = "CREATED_BY"
 	LoadBalancerPoolOrderFieldUpdatedBy LoadBalancerPoolOrderField = "UPDATED_BY"
+	LoadBalancerPoolOrderFieldDeletedAt LoadBalancerPoolOrderField = "DELETED_AT"
+	LoadBalancerPoolOrderFieldDeletedBy LoadBalancerPoolOrderField = "DELETED_BY"
 	LoadBalancerPoolOrderFieldName      LoadBalancerPoolOrderField = "name"
 	LoadBalancerPoolOrderFieldProtocol  LoadBalancerPoolOrderField = "protocol"
 )
@@ -1134,13 +1256,15 @@ var AllLoadBalancerPoolOrderField = []LoadBalancerPoolOrderField{
 	LoadBalancerPoolOrderFieldUpdatedAt,
 	LoadBalancerPoolOrderFieldCreatedBy,
 	LoadBalancerPoolOrderFieldUpdatedBy,
+	LoadBalancerPoolOrderFieldDeletedAt,
+	LoadBalancerPoolOrderFieldDeletedBy,
 	LoadBalancerPoolOrderFieldName,
 	LoadBalancerPoolOrderFieldProtocol,
 }
 
 func (e LoadBalancerPoolOrderField) IsValid() bool {
 	switch e {
-	case LoadBalancerPoolOrderFieldCreatedAt, LoadBalancerPoolOrderFieldUpdatedAt, LoadBalancerPoolOrderFieldCreatedBy, LoadBalancerPoolOrderFieldUpdatedBy, LoadBalancerPoolOrderFieldName, LoadBalancerPoolOrderFieldProtocol:
+	case LoadBalancerPoolOrderFieldCreatedAt, LoadBalancerPoolOrderFieldUpdatedAt, LoadBalancerPoolOrderFieldCreatedBy, LoadBalancerPoolOrderFieldUpdatedBy, LoadBalancerPoolOrderFieldDeletedAt, LoadBalancerPoolOrderFieldDeletedBy, LoadBalancerPoolOrderFieldName, LoadBalancerPoolOrderFieldProtocol:
 		return true
 	}
 	return false
@@ -1215,6 +1339,8 @@ type LoadBalancerPortOrderField string
 const (
 	LoadBalancerPortOrderFieldCreatedAt LoadBalancerPortOrderField = "CREATED_AT"
 	LoadBalancerPortOrderFieldUpdatedAt LoadBalancerPortOrderField = "UPDATED_AT"
+	LoadBalancerPortOrderFieldDeletedAt LoadBalancerPortOrderField = "DELETED_AT"
+	LoadBalancerPortOrderFieldDeletedBy LoadBalancerPortOrderField = "DELETED_BY"
 	LoadBalancerPortOrderFieldCreatedBy LoadBalancerPortOrderField = "CREATED_BY"
 	LoadBalancerPortOrderFieldUpdatedBy LoadBalancerPortOrderField = "UPDATED_BY"
 	LoadBalancerPortOrderFieldNumber    LoadBalancerPortOrderField = "number"
@@ -1224,6 +1350,8 @@ const (
 var AllLoadBalancerPortOrderField = []LoadBalancerPortOrderField{
 	LoadBalancerPortOrderFieldCreatedAt,
 	LoadBalancerPortOrderFieldUpdatedAt,
+	LoadBalancerPortOrderFieldDeletedAt,
+	LoadBalancerPortOrderFieldDeletedBy,
 	LoadBalancerPortOrderFieldCreatedBy,
 	LoadBalancerPortOrderFieldUpdatedBy,
 	LoadBalancerPortOrderFieldNumber,
@@ -1232,7 +1360,7 @@ var AllLoadBalancerPortOrderField = []LoadBalancerPortOrderField{
 
 func (e LoadBalancerPortOrderField) IsValid() bool {
 	switch e {
-	case LoadBalancerPortOrderFieldCreatedAt, LoadBalancerPortOrderFieldUpdatedAt, LoadBalancerPortOrderFieldCreatedBy, LoadBalancerPortOrderFieldUpdatedBy, LoadBalancerPortOrderFieldNumber, LoadBalancerPortOrderFieldName:
+	case LoadBalancerPortOrderFieldCreatedAt, LoadBalancerPortOrderFieldUpdatedAt, LoadBalancerPortOrderFieldDeletedAt, LoadBalancerPortOrderFieldDeletedBy, LoadBalancerPortOrderFieldCreatedBy, LoadBalancerPortOrderFieldUpdatedBy, LoadBalancerPortOrderFieldNumber, LoadBalancerPortOrderFieldName:
 		return true
 	}
 	return false
@@ -1266,6 +1394,8 @@ const (
 	LoadBalancerProviderOrderFieldID        LoadBalancerProviderOrderField = "ID"
 	LoadBalancerProviderOrderFieldCreatedAt LoadBalancerProviderOrderField = "CREATED_AT"
 	LoadBalancerProviderOrderFieldUpdatedAt LoadBalancerProviderOrderField = "UPDATED_AT"
+	LoadBalancerProviderOrderFieldDeletedAt LoadBalancerProviderOrderField = "DELETED_AT"
+	LoadBalancerProviderOrderFieldDeletedBy LoadBalancerProviderOrderField = "DELETED_BY"
 	LoadBalancerProviderOrderFieldCreatedBy LoadBalancerProviderOrderField = "CREATED_BY"
 	LoadBalancerProviderOrderFieldUpdatedBy LoadBalancerProviderOrderField = "UPDATED_BY"
 	LoadBalancerProviderOrderFieldName      LoadBalancerProviderOrderField = "NAME"
@@ -1276,6 +1406,8 @@ var AllLoadBalancerProviderOrderField = []LoadBalancerProviderOrderField{
 	LoadBalancerProviderOrderFieldID,
 	LoadBalancerProviderOrderFieldCreatedAt,
 	LoadBalancerProviderOrderFieldUpdatedAt,
+	LoadBalancerProviderOrderFieldDeletedAt,
+	LoadBalancerProviderOrderFieldDeletedBy,
 	LoadBalancerProviderOrderFieldCreatedBy,
 	LoadBalancerProviderOrderFieldUpdatedBy,
 	LoadBalancerProviderOrderFieldName,
@@ -1284,7 +1416,7 @@ var AllLoadBalancerProviderOrderField = []LoadBalancerProviderOrderField{
 
 func (e LoadBalancerProviderOrderField) IsValid() bool {
 	switch e {
-	case LoadBalancerProviderOrderFieldID, LoadBalancerProviderOrderFieldCreatedAt, LoadBalancerProviderOrderFieldUpdatedAt, LoadBalancerProviderOrderFieldCreatedBy, LoadBalancerProviderOrderFieldUpdatedBy, LoadBalancerProviderOrderFieldName, LoadBalancerProviderOrderFieldOwner:
+	case LoadBalancerProviderOrderFieldID, LoadBalancerProviderOrderFieldCreatedAt, LoadBalancerProviderOrderFieldUpdatedAt, LoadBalancerProviderOrderFieldDeletedAt, LoadBalancerProviderOrderFieldDeletedBy, LoadBalancerProviderOrderFieldCreatedBy, LoadBalancerProviderOrderFieldUpdatedBy, LoadBalancerProviderOrderFieldName, LoadBalancerProviderOrderFieldOwner:
 		return true
 	}
 	return false

--- a/internal/graphclient/schema/schema.graphql
+++ b/internal/graphclient/schema/schema.graphql
@@ -80,6 +80,8 @@ type LoadBalancer implements Node & IPAddressable & MetadataNode @key(fields: "i
 	updatedAt: Time!
 	createdBy: String
 	updatedBy: String
+	deletedAt: Time
+	deletedBy: String
 	"""The name of the load balancer."""
 	name: String!
 	ports(
@@ -148,6 +150,8 @@ enum LoadBalancerOrderField {
 	UPDATED_AT
 	CREATED_BY
 	UPDATED_BY
+	DELETED_AT
+	DELETED_BY
 	NAME
 	OWNER
 }
@@ -904,6 +908,33 @@ input LoadBalancerWhereInput {
 	updatedByNotNil: Boolean
 	updatedByEqualFold: String
 	updatedByContainsFold: String
+	"""deleted_at field predicates"""
+	deletedAt: Time
+	deletedAtNEQ: Time
+	deletedAtIn: [Time!]
+	deletedAtNotIn: [Time!]
+	deletedAtGT: Time
+	deletedAtGTE: Time
+	deletedAtLT: Time
+	deletedAtLTE: Time
+	deletedAtIsNil: Boolean
+	deletedAtNotNil: Boolean
+	"""deleted_by field predicates"""
+	deletedBy: String
+	deletedByNEQ: String
+	deletedByIn: [String!]
+	deletedByNotIn: [String!]
+	deletedByGT: String
+	deletedByGTE: String
+	deletedByLT: String
+	deletedByLTE: String
+	deletedByContains: String
+	deletedByHasPrefix: String
+	deletedByHasSuffix: String
+	deletedByIsNil: Boolean
+	deletedByNotNil: Boolean
+	deletedByEqualFold: String
+	deletedByContainsFold: String
 	"""name field predicates"""
 	name: String
 	nameNEQ: String

--- a/internal/graphclient/schema/schema.graphql
+++ b/internal/graphclient/schema/schema.graphql
@@ -1191,6 +1191,11 @@ type Query {
 		"""The load balancer ID."""
 		id: ID!
 	): LoadBalancer!
+	"""Lookup a load balancer by ID."""
+	loadBalancerHistory(
+		"""The load balancer ID."""
+		id: ID!
+	): LoadBalancer!
 	"""Lookup a pool by ID."""
 	loadBalancerPool(
 		"""The pool ID."""

--- a/internal/graphclient/schema/schema.graphql
+++ b/internal/graphclient/schema/schema.graphql
@@ -159,6 +159,8 @@ type LoadBalancerOrigin implements Node @key(fields: "id") @prefixedID(prefix: "
 	id: ID!
 	createdAt: Time!
 	updatedAt: Time!
+	deletedAt: Time
+	deletedBy: String
 	createdBy: String
 	updatedBy: String
 	name: String!
@@ -206,6 +208,8 @@ input LoadBalancerOriginOrder {
 enum LoadBalancerOriginOrderField {
 	CREATED_AT
 	UPDATED_AT
+	DELETED_AT
+	DELETED_BY
 	CREATED_BY
 	UPDATED_BY
 	name
@@ -254,6 +258,33 @@ input LoadBalancerOriginWhereInput {
 	updatedAtGTE: Time
 	updatedAtLT: Time
 	updatedAtLTE: Time
+	"""deleted_at field predicates"""
+	deletedAt: Time
+	deletedAtNEQ: Time
+	deletedAtIn: [Time!]
+	deletedAtNotIn: [Time!]
+	deletedAtGT: Time
+	deletedAtGTE: Time
+	deletedAtLT: Time
+	deletedAtLTE: Time
+	deletedAtIsNil: Boolean
+	deletedAtNotNil: Boolean
+	"""deleted_by field predicates"""
+	deletedBy: String
+	deletedByNEQ: String
+	deletedByIn: [String!]
+	deletedByNotIn: [String!]
+	deletedByGT: String
+	deletedByGTE: String
+	deletedByLT: String
+	deletedByLTE: String
+	deletedByContains: String
+	deletedByHasPrefix: String
+	deletedByHasSuffix: String
+	deletedByIsNil: Boolean
+	deletedByNotNil: Boolean
+	deletedByEqualFold: String
+	deletedByContainsFold: String
 	"""created_by field predicates"""
 	createdBy: String
 	createdByNEQ: String
@@ -345,6 +376,8 @@ type LoadBalancerPool implements Node @key(fields: "id") @prefixedID(prefix: "lo
 	updatedAt: Time!
 	createdBy: String
 	updatedBy: String
+	deletedAt: Time
+	deletedBy: String
 	name: String!
 	protocol: LoadBalancerPoolProtocol!
 	ownerID: ID!
@@ -410,6 +443,8 @@ enum LoadBalancerPoolOrderField {
 	UPDATED_AT
 	CREATED_BY
 	UPDATED_BY
+	DELETED_AT
+	DELETED_BY
 	name
 	protocol
 }
@@ -490,6 +525,33 @@ input LoadBalancerPoolWhereInput {
 	updatedByNotNil: Boolean
 	updatedByEqualFold: String
 	updatedByContainsFold: String
+	"""deleted_at field predicates"""
+	deletedAt: Time
+	deletedAtNEQ: Time
+	deletedAtIn: [Time!]
+	deletedAtNotIn: [Time!]
+	deletedAtGT: Time
+	deletedAtGTE: Time
+	deletedAtLT: Time
+	deletedAtLTE: Time
+	deletedAtIsNil: Boolean
+	deletedAtNotNil: Boolean
+	"""deleted_by field predicates"""
+	deletedBy: String
+	deletedByNEQ: String
+	deletedByIn: [String!]
+	deletedByNotIn: [String!]
+	deletedByGT: String
+	deletedByGTE: String
+	deletedByLT: String
+	deletedByLTE: String
+	deletedByContains: String
+	deletedByHasPrefix: String
+	deletedByHasSuffix: String
+	deletedByIsNil: Boolean
+	deletedByNotNil: Boolean
+	deletedByEqualFold: String
+	deletedByContainsFold: String
 	"""name field predicates"""
 	name: String
 	nameNEQ: String
@@ -520,6 +582,8 @@ type LoadBalancerPort implements Node @key(fields: "id") @prefixedID(prefix: "lo
 	id: ID!
 	createdAt: Time!
 	updatedAt: Time!
+	deletedAt: Time
+	deletedBy: String
 	createdBy: String
 	updatedBy: String
 	number: Int!
@@ -565,6 +629,8 @@ input LoadBalancerPortOrder {
 enum LoadBalancerPortOrderField {
 	CREATED_AT
 	UPDATED_AT
+	DELETED_AT
+	DELETED_BY
 	CREATED_BY
 	UPDATED_BY
 	number
@@ -610,6 +676,33 @@ input LoadBalancerPortWhereInput {
 	updatedAtGTE: Time
 	updatedAtLT: Time
 	updatedAtLTE: Time
+	"""deleted_at field predicates"""
+	deletedAt: Time
+	deletedAtNEQ: Time
+	deletedAtIn: [Time!]
+	deletedAtNotIn: [Time!]
+	deletedAtGT: Time
+	deletedAtGTE: Time
+	deletedAtLT: Time
+	deletedAtLTE: Time
+	deletedAtIsNil: Boolean
+	deletedAtNotNil: Boolean
+	"""deleted_by field predicates"""
+	deletedBy: String
+	deletedByNEQ: String
+	deletedByIn: [String!]
+	deletedByNotIn: [String!]
+	deletedByGT: String
+	deletedByGTE: String
+	deletedByLT: String
+	deletedByLTE: String
+	deletedByContains: String
+	deletedByHasPrefix: String
+	deletedByHasSuffix: String
+	deletedByIsNil: Boolean
+	deletedByNotNil: Boolean
+	deletedByEqualFold: String
+	deletedByContainsFold: String
 	"""created_by field predicates"""
 	createdBy: String
 	createdByNEQ: String
@@ -677,6 +770,8 @@ type LoadBalancerProvider implements Node @key(fields: "id") @prefixedID(prefix:
 	id: ID!
 	createdAt: Time!
 	updatedAt: Time!
+	deletedAt: Time
+	deletedBy: String
 	createdBy: String
 	updatedBy: String
 	"""The name of the load balancer provider."""
@@ -741,6 +836,8 @@ enum LoadBalancerProviderOrderField {
 	ID
 	CREATED_AT
 	UPDATED_AT
+	DELETED_AT
+	DELETED_BY
 	CREATED_BY
 	UPDATED_BY
 	NAME
@@ -786,6 +883,33 @@ input LoadBalancerProviderWhereInput {
 	updatedAtGTE: Time
 	updatedAtLT: Time
 	updatedAtLTE: Time
+	"""deleted_at field predicates"""
+	deletedAt: Time
+	deletedAtNEQ: Time
+	deletedAtIn: [Time!]
+	deletedAtNotIn: [Time!]
+	deletedAtGT: Time
+	deletedAtGTE: Time
+	deletedAtLT: Time
+	deletedAtLTE: Time
+	deletedAtIsNil: Boolean
+	deletedAtNotNil: Boolean
+	"""deleted_by field predicates"""
+	deletedBy: String
+	deletedByNEQ: String
+	deletedByIn: [String!]
+	deletedByNotIn: [String!]
+	deletedByGT: String
+	deletedByGTE: String
+	deletedByLT: String
+	deletedByLTE: String
+	deletedByContains: String
+	deletedByHasPrefix: String
+	deletedByHasSuffix: String
+	deletedByIsNil: Boolean
+	deletedByNotNil: Boolean
+	deletedByEqualFold: String
+	deletedByContainsFold: String
 	"""created_by field predicates"""
 	createdBy: String
 	createdByNEQ: String

--- a/internal/manualhooks/hooks.go
+++ b/internal/manualhooks/hooks.go
@@ -266,7 +266,7 @@ func LoadBalancerHooks() []ent.Hook {
 				}
 
 				msg := events.ChangeMessage{
-					EventType:            eventType(m.Op()),
+					EventType:            string(events.DeleteChangeType),
 					SubjectID:            objID,
 					AdditionalSubjectIDs: additionalSubjects,
 					Timestamp:            time.Now().UTC(),
@@ -283,6 +283,7 @@ func LoadBalancerHooks() []ent.Hook {
 	)
 	// }
 
+	// only trigger create/update hook when the deleted_at field is not set
 	cuhook = hook.If(
 		cuhook,
 		hook.Not(
@@ -295,6 +296,9 @@ func LoadBalancerHooks() []ent.Hook {
 			),
 		),
 	)
+
+	// TODO: should we not trigger an event when something is permanently deleted?
+	//       should this be a different type of message?
 
 	return []ent.Hook{cuhook, dhook}
 }

--- a/internal/manualhooks/hooks.go
+++ b/internal/manualhooks/hooks.go
@@ -304,749 +304,213 @@ func LoadBalancerHooks() []ent.Hook {
 }
 
 func OriginHooks() []ent.Hook {
-	return []ent.Hook{
-		hook.On(
-			func(next ent.Mutator) ent.Mutator {
-				return hook.OriginFunc(func(ctx context.Context, m *generated.OriginMutation) (ent.Value, error) {
-					var err error
-					additionalSubjects := []gidx.PrefixedID{}
-					relationships := []events.AuthRelationshipRelation{}
+	// return []ent.Hook{
+	cuhook := hook.On(
+		func(next ent.Mutator) ent.Mutator {
+			return hook.OriginFunc(func(ctx context.Context, m *generated.OriginMutation) (ent.Value, error) {
+				var err error
+				additionalSubjects := []gidx.PrefixedID{}
+				relationships := []events.AuthRelationshipRelation{}
 
-					objID, ok := m.ID()
-					if !ok {
-						return nil, fmt.Errorf("object doesn't have an id %s", objID)
-					}
+				objID, ok := m.ID()
+				if !ok {
+					return nil, fmt.Errorf("object doesn't have an id %s", objID)
+				}
 
-					changeset := []events.FieldChange{}
-					cv_created_at := ""
-					created_at, ok := m.CreatedAt()
+				changeset := []events.FieldChange{}
+				cv_created_at := ""
+				created_at, ok := m.CreatedAt()
 
-					if ok {
-						cv_created_at = created_at.Format(time.RFC3339)
-						pv_created_at := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldCreatedAt(ctx)
-							if err != nil {
-								pv_created_at = "<unknown>"
-							} else {
-								pv_created_at = ov.Format(time.RFC3339)
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "created_at",
-							PreviousValue: pv_created_at,
-							CurrentValue:  cv_created_at,
-						})
-					}
-
-					cv_updated_at := ""
-					updated_at, ok := m.UpdatedAt()
-
-					if ok {
-						cv_updated_at = updated_at.Format(time.RFC3339)
-						pv_updated_at := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldUpdatedAt(ctx)
-							if err != nil {
-								pv_updated_at = "<unknown>"
-							} else {
-								pv_updated_at = ov.Format(time.RFC3339)
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "updated_at",
-							PreviousValue: pv_updated_at,
-							CurrentValue:  cv_updated_at,
-						})
-					}
-
-					cv_name := ""
-					name, ok := m.Name()
-
-					if ok {
-						cv_name = fmt.Sprintf("%s", fmt.Sprint(name))
-						pv_name := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldName(ctx)
-							if err != nil {
-								pv_name = "<unknown>"
-							} else {
-								pv_name = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "name",
-							PreviousValue: pv_name,
-							CurrentValue:  cv_name,
-						})
-					}
-
-					cv_target := ""
-					target, ok := m.Target()
-
-					if ok {
-						cv_target = fmt.Sprintf("%s", fmt.Sprint(target))
-						pv_target := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldTarget(ctx)
-							if err != nil {
-								pv_target = "<unknown>"
-							} else {
-								pv_target = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "target",
-							PreviousValue: pv_target,
-							CurrentValue:  cv_target,
-						})
-					}
-
-					cv_port_number := ""
-					port_number, ok := m.PortNumber()
-
-					if ok {
-						cv_port_number = fmt.Sprintf("%s", fmt.Sprint(port_number))
-						pv_port_number := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldPortNumber(ctx)
-							if err != nil {
-								pv_port_number = "<unknown>"
-							} else {
-								pv_port_number = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "port_number",
-							PreviousValue: pv_port_number,
-							CurrentValue:  cv_port_number,
-						})
-					}
-
-					cv_active := ""
-					active, ok := m.Active()
-
-					if ok {
-						cv_active = fmt.Sprintf("%s", fmt.Sprint(active))
-						pv_active := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldActive(ctx)
-							if err != nil {
-								pv_active = "<unknown>"
-							} else {
-								pv_active = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "active",
-							PreviousValue: pv_active,
-							CurrentValue:  cv_active,
-						})
-					}
-
-					cv_pool_id := ""
-					pool_id, ok := m.PoolID()
-					if !ok && !m.Op().Is(ent.OpCreate) {
-						// since we are doing an update or delete and these fields didn't change, load the "old" value
-						pool_id, err = m.OldPoolID(ctx)
+				if ok {
+					cv_created_at = created_at.Format(time.RFC3339)
+					pv_created_at := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldCreatedAt(ctx)
 						if err != nil {
-							return nil, err
-						}
-					}
-					additionalSubjects = append(additionalSubjects, pool_id)
-
-					if ok {
-						cv_pool_id = fmt.Sprintf("%s", fmt.Sprint(pool_id))
-						pv_pool_id := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldPoolID(ctx)
-							if err != nil {
-								pv_pool_id = "<unknown>"
-							} else {
-								pv_pool_id = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "pool_id",
-							PreviousValue: pv_pool_id,
-							CurrentValue:  cv_pool_id,
-						})
-					}
-
-					msg := events.ChangeMessage{
-						EventType:            eventType(m.Op()),
-						SubjectID:            objID,
-						AdditionalSubjectIDs: additionalSubjects,
-						Timestamp:            time.Now().UTC(),
-						FieldChanges:         changeset,
-					}
-
-					// complete the mutation before we process the event
-					retValue, err := next.Mutate(ctx, m)
-					if err != nil {
-						return retValue, err
-					}
-
-					// Ensure we have additional relevant subjects in the msg
-					addSubjPorts, err := m.Client().Port.Query().WithPools().WithLoadBalancer().Where(port.HasPoolsWith(pool.HasOriginsWith(origin.IDEQ(objID)))).All(ctx)
-					if err == nil {
-						for _, port := range addSubjPorts {
-							if !slices.Contains(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.LocationID) {
-								msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.LocationID)
-							}
-
-							if !slices.Contains(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.ProviderID) {
-								msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.ProviderID)
-							}
-
-							if !slices.Contains(msg.AdditionalSubjectIDs, port.LoadBalancerID) {
-								msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.LoadBalancerID)
-							}
-
-							for _, pool := range port.Edges.Pools {
-								if !slices.Contains(msg.AdditionalSubjectIDs, pool.ID) {
-									msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, pool.ID)
-								}
-
-								if !slices.Contains(msg.AdditionalSubjectIDs, pool.OwnerID) {
-									msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, pool.OwnerID)
-								}
-							}
+							pv_created_at = "<unknown>"
+						} else {
+							pv_created_at = ov.Format(time.RFC3339)
 						}
 					}
 
-					if len(relationships) != 0 && eventType(m.Op()) == string(events.CreateChangeType) {
-						if err := permissions.CreateAuthRelationships(ctx, "load-balancer-origin", objID, relationships...); err != nil {
-							return nil, fmt.Errorf("relationship request failed with error: %w", err)
-						}
-					}
+					changeset = append(changeset, events.FieldChange{
+						Field:         "created_at",
+						PreviousValue: pv_created_at,
+						CurrentValue:  cv_created_at,
+					})
+				}
 
-					if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer-origin", msg); err != nil {
-						return nil, fmt.Errorf("failed to publish change: %w", err)
-					}
+				cv_updated_at := ""
+				updated_at, ok := m.UpdatedAt()
 
-					return retValue, nil
-				})
-			},
-			ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne,
-		),
-
-		// Delete Hook
-		hook.On(
-			func(next ent.Mutator) ent.Mutator {
-				return hook.OriginFunc(func(ctx context.Context, m *generated.OriginMutation) (ent.Value, error) {
-					additionalSubjects := []gidx.PrefixedID{}
-					relationships := []events.AuthRelationshipRelation{}
-
-					objID, ok := m.ID()
-					if !ok {
-						return nil, fmt.Errorf("object doesn't have an id %s", objID)
-					}
-
-					dbObj, err := m.Client().Origin.Get(ctx, objID)
-					if err != nil {
-						return nil, fmt.Errorf("failed to load object to get values for event, err %w", err)
-					}
-
-					additionalSubjects = append(additionalSubjects, dbObj.PoolID)
-
-					// Ensure we have additional relevant subjects in the msg
-					addSubjPorts, err := m.Client().Port.Query().WithPools().WithLoadBalancer().Where(port.HasPoolsWith(pool.HasOriginsWith(origin.IDEQ(objID)))).All(ctx)
-					if err == nil {
-						for _, port := range addSubjPorts {
-							for _, pool := range port.Edges.Pools {
-								if !slices.Contains(additionalSubjects, pool.ID) {
-									additionalSubjects = append(additionalSubjects, pool.ID)
-								}
-
-								if !slices.Contains(additionalSubjects, pool.OwnerID) {
-									additionalSubjects = append(additionalSubjects, pool.OwnerID)
-								}
-							}
-
-							if !slices.Contains(additionalSubjects, port.LoadBalancerID) {
-								additionalSubjects = append(additionalSubjects, port.LoadBalancerID)
-							}
-
-							if !slices.Contains(additionalSubjects, port.Edges.LoadBalancer.LocationID) {
-								additionalSubjects = append(additionalSubjects, port.Edges.LoadBalancer.LocationID)
-							}
-
-							if !slices.Contains(additionalSubjects, port.Edges.LoadBalancer.ProviderID) {
-								additionalSubjects = append(additionalSubjects, port.Edges.LoadBalancer.ProviderID)
-							}
-						}
-					}
-
-					// we have all the info we need, now complete the mutation before we process the event
-					retValue, err := next.Mutate(ctx, m)
-					if err != nil {
-						return retValue, err
-					}
-
-					if len(relationships) != 0 {
-						if err := permissions.DeleteAuthRelationships(ctx, "load-balancer-origin", objID, relationships...); err != nil {
-							return nil, fmt.Errorf("relationship request failed with error: %w", err)
-						}
-					}
-
-					msg := events.ChangeMessage{
-						EventType:            eventType(m.Op()),
-						SubjectID:            objID,
-						AdditionalSubjectIDs: additionalSubjects,
-						Timestamp:            time.Now().UTC(),
-					}
-
-					if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer-origin", msg); err != nil {
-						return nil, fmt.Errorf("failed to publish change: %w", err)
-					}
-
-					return retValue, nil
-				})
-			},
-			ent.OpDelete|ent.OpDeleteOne,
-		),
-	}
-}
-
-func PoolHooks() []ent.Hook {
-	return []ent.Hook{
-		hook.On(
-			func(next ent.Mutator) ent.Mutator {
-				return hook.PoolFunc(func(ctx context.Context, m *generated.PoolMutation) (ent.Value, error) {
-					var err error
-					additionalSubjects := []gidx.PrefixedID{}
-					relationships := []events.AuthRelationshipRelation{}
-
-					objID, ok := m.ID()
-					if !ok {
-						return nil, fmt.Errorf("object doesn't have an id %s", objID)
-					}
-
-					changeset := []events.FieldChange{}
-					cv_created_at := ""
-					created_at, ok := m.CreatedAt()
-
-					if ok {
-						cv_created_at = created_at.Format(time.RFC3339)
-						pv_created_at := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldCreatedAt(ctx)
-							if err != nil {
-								pv_created_at = "<unknown>"
-							} else {
-								pv_created_at = ov.Format(time.RFC3339)
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "created_at",
-							PreviousValue: pv_created_at,
-							CurrentValue:  cv_created_at,
-						})
-					}
-
-					cv_updated_at := ""
-					updated_at, ok := m.UpdatedAt()
-
-					if ok {
-						cv_updated_at = updated_at.Format(time.RFC3339)
-						pv_updated_at := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldUpdatedAt(ctx)
-							if err != nil {
-								pv_updated_at = "<unknown>"
-							} else {
-								pv_updated_at = ov.Format(time.RFC3339)
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "updated_at",
-							PreviousValue: pv_updated_at,
-							CurrentValue:  cv_updated_at,
-						})
-					}
-
-					cv_name := ""
-					name, ok := m.Name()
-
-					if ok {
-						cv_name = fmt.Sprintf("%s", fmt.Sprint(name))
-						pv_name := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldName(ctx)
-							if err != nil {
-								pv_name = "<unknown>"
-							} else {
-								pv_name = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "name",
-							PreviousValue: pv_name,
-							CurrentValue:  cv_name,
-						})
-					}
-
-					cv_protocol := ""
-					protocol, ok := m.Protocol()
-
-					if ok {
-						cv_protocol = fmt.Sprintf("%s", fmt.Sprint(protocol))
-						pv_protocol := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldProtocol(ctx)
-							if err != nil {
-								pv_protocol = "<unknown>"
-							} else {
-								pv_protocol = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "protocol",
-							PreviousValue: pv_protocol,
-							CurrentValue:  cv_protocol,
-						})
-					}
-
-					cv_owner_id := ""
-					owner_id, ok := m.OwnerID()
-					if !ok && !m.Op().Is(ent.OpCreate) {
-						// since we are doing an update or delete and these fields didn't change, load the "old" value
-						owner_id, err = m.OldOwnerID(ctx)
+				if ok {
+					cv_updated_at = updated_at.Format(time.RFC3339)
+					pv_updated_at := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldUpdatedAt(ctx)
 						if err != nil {
-							return nil, err
+							pv_updated_at = "<unknown>"
+						} else {
+							pv_updated_at = ov.Format(time.RFC3339)
 						}
 					}
-					additionalSubjects = append(additionalSubjects, owner_id)
 
-					relationships = append(relationships, events.AuthRelationshipRelation{
-						Relation:  "owner",
-						SubjectID: owner_id,
+					changeset = append(changeset, events.FieldChange{
+						Field:         "updated_at",
+						PreviousValue: pv_updated_at,
+						CurrentValue:  cv_updated_at,
 					})
+				}
 
-					if ok {
-						cv_owner_id = fmt.Sprintf("%s", fmt.Sprint(owner_id))
-						pv_owner_id := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldOwnerID(ctx)
-							if err != nil {
-								pv_owner_id = "<unknown>"
-							} else {
-								pv_owner_id = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
-						}
+				cv_name := ""
+				name, ok := m.Name()
 
-						changeset = append(changeset, events.FieldChange{
-							Field:         "owner_id",
-							PreviousValue: pv_owner_id,
-							CurrentValue:  cv_owner_id,
-						})
-					}
-
-					msg := events.ChangeMessage{
-						EventType:            eventType(m.Op()),
-						SubjectID:            objID,
-						AdditionalSubjectIDs: additionalSubjects,
-						Timestamp:            time.Now().UTC(),
-						FieldChanges:         changeset,
-					}
-
-					// complete the mutation before we process the event
-					retValue, err := next.Mutate(ctx, m)
-					if err != nil {
-						return retValue, err
-					}
-
-					// Ensure we have additional relevant subjects in the msg
-					addSubjPorts, err := m.Client().Port.Query().WithLoadBalancer().WithPools(func(q *generated.PoolQuery) {
-						q.WithOrigins()
-					}).Where(port.HasPoolsWith(pool.IDEQ(objID))).All(ctx)
-					if err == nil {
-						for _, port := range addSubjPorts {
-							for _, pool := range port.Edges.Pools {
-								for _, origin := range pool.Edges.Origins {
-									if !slices.Contains(msg.AdditionalSubjectIDs, origin.ID) {
-										msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, origin.ID)
-									}
-								}
-							}
-
-							if !slices.Contains(msg.AdditionalSubjectIDs, port.ID) && objID != port.ID {
-								msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.ID)
-							}
-
-							if !slices.Contains(msg.AdditionalSubjectIDs, port.LoadBalancerID) {
-								msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.LoadBalancerID)
-							}
-
-							if !slices.Contains(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.LocationID) {
-								msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.LocationID)
-							}
-
-							if !slices.Contains(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.ProviderID) {
-								msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.ProviderID)
-							}
+				if ok {
+					cv_name = fmt.Sprintf("%s", fmt.Sprint(name))
+					pv_name := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldName(ctx)
+						if err != nil {
+							pv_name = "<unknown>"
+						} else {
+							pv_name = fmt.Sprintf("%s", fmt.Sprint(ov))
 						}
 					}
 
-					if len(relationships) != 0 && eventType(m.Op()) == string(events.CreateChangeType) {
-						if err := permissions.CreateAuthRelationships(ctx, "load-balancer-pool", objID, relationships...); err != nil {
-							return nil, fmt.Errorf("relationship request failed with error: %w", err)
-						}
-					}
-
-					if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer-pool", msg); err != nil {
-						return nil, fmt.Errorf("failed to publish change: %w", err)
-					}
-
-					return retValue, nil
-				})
-			},
-			ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne,
-		),
-
-		// Delete Hook
-		hook.On(
-			func(next ent.Mutator) ent.Mutator {
-				return hook.PoolFunc(func(ctx context.Context, m *generated.PoolMutation) (ent.Value, error) {
-					additionalSubjects := []gidx.PrefixedID{}
-					relationships := []events.AuthRelationshipRelation{}
-
-					objID, ok := m.ID()
-					if !ok {
-						return nil, fmt.Errorf("object doesn't have an id %s", objID)
-					}
-
-					dbObj, err := m.Client().Pool.Get(ctx, objID)
-					if err != nil {
-						return nil, fmt.Errorf("failed to load object to get values for event, err %w", err)
-					}
-
-					additionalSubjects = append(additionalSubjects, dbObj.OwnerID)
-
-					// Ensure we have additional relevant subjects in the msg
-					addSubjPorts, err := m.Client().Port.Query().WithLoadBalancer().Where(port.HasPoolsWith(pool.IDEQ(objID))).All(ctx)
-					if err == nil {
-						for _, port := range addSubjPorts {
-							if !slices.Contains(additionalSubjects, port.Edges.LoadBalancer.LocationID) {
-								additionalSubjects = append(additionalSubjects, port.Edges.LoadBalancer.LocationID)
-							}
-
-							if !slices.Contains(additionalSubjects, port.Edges.LoadBalancer.ProviderID) {
-								additionalSubjects = append(additionalSubjects, port.Edges.LoadBalancer.ProviderID)
-							}
-
-							if !slices.Contains(additionalSubjects, port.LoadBalancerID) {
-								additionalSubjects = append(additionalSubjects, port.LoadBalancerID)
-							}
-						}
-					}
-
-					relationships = append(relationships, events.AuthRelationshipRelation{
-						Relation:  "owner",
-						SubjectID: dbObj.OwnerID,
+					changeset = append(changeset, events.FieldChange{
+						Field:         "name",
+						PreviousValue: pv_name,
+						CurrentValue:  cv_name,
 					})
+				}
 
-					// we have all the info we need, now complete the mutation before we process the event
-					retValue, err := next.Mutate(ctx, m)
+				cv_target := ""
+				target, ok := m.Target()
+
+				if ok {
+					cv_target = fmt.Sprintf("%s", fmt.Sprint(target))
+					pv_target := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldTarget(ctx)
+						if err != nil {
+							pv_target = "<unknown>"
+						} else {
+							pv_target = fmt.Sprintf("%s", fmt.Sprint(ov))
+						}
+					}
+
+					changeset = append(changeset, events.FieldChange{
+						Field:         "target",
+						PreviousValue: pv_target,
+						CurrentValue:  cv_target,
+					})
+				}
+
+				cv_port_number := ""
+				port_number, ok := m.PortNumber()
+
+				if ok {
+					cv_port_number = fmt.Sprintf("%s", fmt.Sprint(port_number))
+					pv_port_number := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldPortNumber(ctx)
+						if err != nil {
+							pv_port_number = "<unknown>"
+						} else {
+							pv_port_number = fmt.Sprintf("%s", fmt.Sprint(ov))
+						}
+					}
+
+					changeset = append(changeset, events.FieldChange{
+						Field:         "port_number",
+						PreviousValue: pv_port_number,
+						CurrentValue:  cv_port_number,
+					})
+				}
+
+				cv_active := ""
+				active, ok := m.Active()
+
+				if ok {
+					cv_active = fmt.Sprintf("%s", fmt.Sprint(active))
+					pv_active := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldActive(ctx)
+						if err != nil {
+							pv_active = "<unknown>"
+						} else {
+							pv_active = fmt.Sprintf("%s", fmt.Sprint(ov))
+						}
+					}
+
+					changeset = append(changeset, events.FieldChange{
+						Field:         "active",
+						PreviousValue: pv_active,
+						CurrentValue:  cv_active,
+					})
+				}
+
+				cv_pool_id := ""
+				pool_id, ok := m.PoolID()
+				if !ok && !m.Op().Is(ent.OpCreate) {
+					// since we are doing an update or delete and these fields didn't change, load the "old" value
+					pool_id, err = m.OldPoolID(ctx)
 					if err != nil {
-						return retValue, err
+						return nil, err
 					}
+				}
+				additionalSubjects = append(additionalSubjects, pool_id)
 
-					if len(relationships) != 0 {
-						if err := permissions.DeleteAuthRelationships(ctx, "load-balancer-pool", objID, relationships...); err != nil {
-							return nil, fmt.Errorf("relationship request failed with error: %w", err)
+				if ok {
+					cv_pool_id = fmt.Sprintf("%s", fmt.Sprint(pool_id))
+					pv_pool_id := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldPoolID(ctx)
+						if err != nil {
+							pv_pool_id = "<unknown>"
+						} else {
+							pv_pool_id = fmt.Sprintf("%s", fmt.Sprint(ov))
 						}
 					}
 
-					msg := events.ChangeMessage{
-						EventType:            eventType(m.Op()),
-						SubjectID:            objID,
-						AdditionalSubjectIDs: additionalSubjects,
-						Timestamp:            time.Now().UTC(),
-					}
+					changeset = append(changeset, events.FieldChange{
+						Field:         "pool_id",
+						PreviousValue: pv_pool_id,
+						CurrentValue:  cv_pool_id,
+					})
+				}
 
-					if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer-pool", msg); err != nil {
-						return nil, fmt.Errorf("failed to publish change: %w", err)
-					}
+				msg := events.ChangeMessage{
+					EventType:            eventType(m.Op()),
+					SubjectID:            objID,
+					AdditionalSubjectIDs: additionalSubjects,
+					Timestamp:            time.Now().UTC(),
+					FieldChanges:         changeset,
+				}
 
-					return retValue, nil
-				})
-			},
-			ent.OpDelete|ent.OpDeleteOne,
-		),
-	}
-}
+				// complete the mutation before we process the event
+				retValue, err := next.Mutate(ctx, m)
+				if err != nil {
+					return retValue, err
+				}
 
-func PortHooks() []ent.Hook {
-	return []ent.Hook{
-		hook.On(
-			func(next ent.Mutator) ent.Mutator {
-				return hook.PortFunc(func(ctx context.Context, m *generated.PortMutation) (ent.Value, error) {
-					var err error
-					additionalSubjects := []gidx.PrefixedID{}
-					relationships := []events.AuthRelationshipRelation{}
-
-					objID, ok := m.ID()
-					if !ok {
-						return nil, fmt.Errorf("object doesn't have an id %s", objID)
-					}
-
-					changeset := []events.FieldChange{}
-					cv_created_at := ""
-					created_at, ok := m.CreatedAt()
-
-					if ok {
-						cv_created_at = created_at.Format(time.RFC3339)
-						pv_created_at := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldCreatedAt(ctx)
-							if err != nil {
-								pv_created_at = "<unknown>"
-							} else {
-								pv_created_at = ov.Format(time.RFC3339)
-							}
+				// Ensure we have additional relevant subjects in the msg
+				addSubjPorts, err := m.Client().Port.Query().WithPools().WithLoadBalancer().Where(port.HasPoolsWith(pool.HasOriginsWith(origin.IDEQ(objID)))).All(ctx)
+				if err == nil {
+					for _, port := range addSubjPorts {
+						if !slices.Contains(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.LocationID) {
+							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.LocationID)
 						}
 
-						changeset = append(changeset, events.FieldChange{
-							Field:         "created_at",
-							PreviousValue: pv_created_at,
-							CurrentValue:  cv_created_at,
-						})
-					}
-
-					cv_updated_at := ""
-					updated_at, ok := m.UpdatedAt()
-
-					if ok {
-						cv_updated_at = updated_at.Format(time.RFC3339)
-						pv_updated_at := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldUpdatedAt(ctx)
-							if err != nil {
-								pv_updated_at = "<unknown>"
-							} else {
-								pv_updated_at = ov.Format(time.RFC3339)
-							}
+						if !slices.Contains(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.ProviderID) {
+							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.ProviderID)
 						}
 
-						changeset = append(changeset, events.FieldChange{
-							Field:         "updated_at",
-							PreviousValue: pv_updated_at,
-							CurrentValue:  cv_updated_at,
-						})
-					}
-
-					cv_number := ""
-					number, ok := m.Number()
-
-					if ok {
-						cv_number = fmt.Sprintf("%s", fmt.Sprint(number))
-						pv_number := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldNumber(ctx)
-							if err != nil {
-								pv_number = "<unknown>"
-							} else {
-								pv_number = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
+						if !slices.Contains(msg.AdditionalSubjectIDs, port.LoadBalancerID) {
+							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.LoadBalancerID)
 						}
 
-						changeset = append(changeset, events.FieldChange{
-							Field:         "number",
-							PreviousValue: pv_number,
-							CurrentValue:  cv_number,
-						})
-					}
-
-					cv_name := ""
-					name, ok := m.Name()
-
-					if ok {
-						cv_name = fmt.Sprintf("%s", fmt.Sprint(name))
-						pv_name := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldName(ctx)
-							if err != nil {
-								pv_name = "<unknown>"
-							} else {
-								pv_name = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "name",
-							PreviousValue: pv_name,
-							CurrentValue:  cv_name,
-						})
-					}
-
-					cv_load_balancer_id := ""
-					load_balancer_id, ok := m.LoadBalancerID()
-					if ok {
-						cv_load_balancer_id = fmt.Sprintf("%s", fmt.Sprint(load_balancer_id))
-						pv_load_balancer_id := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldLoadBalancerID(ctx)
-							if err != nil {
-								pv_load_balancer_id = "<unknown>"
-							} else {
-								pv_load_balancer_id = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "load_balancer_id",
-							PreviousValue: pv_load_balancer_id,
-							CurrentValue:  cv_load_balancer_id,
-						})
-					}
-
-					msg := events.ChangeMessage{
-						EventType:            eventType(m.Op()),
-						SubjectID:            objID,
-						AdditionalSubjectIDs: additionalSubjects,
-						Timestamp:            time.Now().UTC(),
-						FieldChanges:         changeset,
-					}
-
-					// complete the mutation before we process the event
-					retValue, err := next.Mutate(ctx, m)
-					if err != nil {
-						return retValue, err
-					}
-
-					// Ensure we have additional relevant subjects in the event msg
-					addSubjPort, err := m.Client().Port.Query().WithPools().WithLoadBalancer().Where(port.IDEQ(objID)).Only(ctx)
-					if err == nil {
-						if !slices.Contains(msg.AdditionalSubjectIDs, addSubjPort.LoadBalancerID) {
-							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, addSubjPort.LoadBalancerID)
-						}
-
-						if !slices.Contains(msg.AdditionalSubjectIDs, addSubjPort.Edges.LoadBalancer.LocationID) {
-							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, addSubjPort.Edges.LoadBalancer.LocationID)
-						}
-
-						if !slices.Contains(msg.AdditionalSubjectIDs, addSubjPort.Edges.LoadBalancer.OwnerID) {
-							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, addSubjPort.Edges.LoadBalancer.OwnerID)
-						}
-
-						if !slices.Contains(msg.AdditionalSubjectIDs, addSubjPort.Edges.LoadBalancer.ProviderID) {
-							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, addSubjPort.Edges.LoadBalancer.ProviderID)
-						}
-
-						for _, pool := range addSubjPort.Edges.Pools {
+						for _, pool := range port.Edges.Pools {
 							if !slices.Contains(msg.AdditionalSubjectIDs, pool.ID) {
 								msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, pool.ID)
 							}
@@ -1056,75 +520,666 @@ func PortHooks() []ent.Hook {
 							}
 						}
 					}
+				}
 
-					if len(relationships) != 0 && eventType(m.Op()) == string(events.CreateChangeType) {
-						if err := permissions.CreateAuthRelationships(ctx, "load-balancer-port", objID, relationships...); err != nil {
-							return nil, fmt.Errorf("relationship request failed with error: %w", err)
+				if len(relationships) != 0 && eventType(m.Op()) == string(events.CreateChangeType) {
+					if err := permissions.CreateAuthRelationships(ctx, "load-balancer-origin", objID, relationships...); err != nil {
+						return nil, fmt.Errorf("relationship request failed with error: %w", err)
+					}
+				}
+
+				if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer-origin", msg); err != nil {
+					return nil, fmt.Errorf("failed to publish change: %w", err)
+				}
+
+				return retValue, nil
+			})
+		},
+		ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne,
+	)
+
+	// Delete Hook
+	dhook := hook.On(
+		func(next ent.Mutator) ent.Mutator {
+			return hook.OriginFunc(func(ctx context.Context, m *generated.OriginMutation) (ent.Value, error) {
+				additionalSubjects := []gidx.PrefixedID{}
+				relationships := []events.AuthRelationshipRelation{}
+
+				objID, ok := m.ID()
+				if !ok {
+					return nil, fmt.Errorf("object doesn't have an id %s", objID)
+				}
+
+				dbObj, err := m.Client().Origin.Get(ctx, objID)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load object to get values for event, err %w", err)
+				}
+
+				additionalSubjects = append(additionalSubjects, dbObj.PoolID)
+
+				// Ensure we have additional relevant subjects in the msg
+				addSubjPorts, err := m.Client().Port.Query().WithPools().WithLoadBalancer().Where(port.HasPoolsWith(pool.HasOriginsWith(origin.IDEQ(objID)))).All(ctx)
+				if err == nil {
+					for _, port := range addSubjPorts {
+						for _, pool := range port.Edges.Pools {
+							if !slices.Contains(additionalSubjects, pool.ID) {
+								additionalSubjects = append(additionalSubjects, pool.ID)
+							}
+
+							if !slices.Contains(additionalSubjects, pool.OwnerID) {
+								additionalSubjects = append(additionalSubjects, pool.OwnerID)
+							}
+						}
+
+						if !slices.Contains(additionalSubjects, port.LoadBalancerID) {
+							additionalSubjects = append(additionalSubjects, port.LoadBalancerID)
+						}
+
+						if !slices.Contains(additionalSubjects, port.Edges.LoadBalancer.LocationID) {
+							additionalSubjects = append(additionalSubjects, port.Edges.LoadBalancer.LocationID)
+						}
+
+						if !slices.Contains(additionalSubjects, port.Edges.LoadBalancer.ProviderID) {
+							additionalSubjects = append(additionalSubjects, port.Edges.LoadBalancer.ProviderID)
+						}
+					}
+				}
+
+				// we have all the info we need, now complete the mutation before we process the event
+				retValue, err := next.Mutate(ctx, m)
+				if err != nil {
+					return retValue, err
+				}
+
+				if len(relationships) != 0 {
+					if err := permissions.DeleteAuthRelationships(ctx, "load-balancer-origin", objID, relationships...); err != nil {
+						return nil, fmt.Errorf("relationship request failed with error: %w", err)
+					}
+				}
+
+				msg := events.ChangeMessage{
+					EventType:            string(events.DeleteChangeType),
+					SubjectID:            objID,
+					AdditionalSubjectIDs: additionalSubjects,
+					Timestamp:            time.Now().UTC(),
+				}
+
+				if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer-origin", msg); err != nil {
+					return nil, fmt.Errorf("failed to publish change: %w", err)
+				}
+
+				return retValue, nil
+			})
+		},
+		ent.OpDelete|ent.OpDeleteOne,
+	)
+
+	// only trigger create/update hook when the deleted_at field is not set
+	cuhook = hook.If(
+		cuhook,
+		hook.Not(
+			hook.And(
+				hook.Or(
+					hook.HasOp(ent.OpUpdate),
+					hook.HasOp(ent.OpUpdateOne),
+				),
+				hook.HasFields("deleted_at"),
+			),
+		),
+	)
+
+	// TODO: should we not trigger an event when something is permanently deleted?
+	//       should this be a different type of message?
+
+	return []ent.Hook{cuhook, dhook}
+	// }
+}
+
+func PoolHooks() []ent.Hook {
+	// return []ent.Hook{
+	cuhook := hook.On(
+		func(next ent.Mutator) ent.Mutator {
+			return hook.PoolFunc(func(ctx context.Context, m *generated.PoolMutation) (ent.Value, error) {
+				var err error
+				additionalSubjects := []gidx.PrefixedID{}
+				relationships := []events.AuthRelationshipRelation{}
+
+				objID, ok := m.ID()
+				if !ok {
+					return nil, fmt.Errorf("object doesn't have an id %s", objID)
+				}
+
+				changeset := []events.FieldChange{}
+				cv_created_at := ""
+				created_at, ok := m.CreatedAt()
+
+				if ok {
+					cv_created_at = created_at.Format(time.RFC3339)
+					pv_created_at := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldCreatedAt(ctx)
+						if err != nil {
+							pv_created_at = "<unknown>"
+						} else {
+							pv_created_at = ov.Format(time.RFC3339)
 						}
 					}
 
-					if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer-port", msg); err != nil {
-						return nil, fmt.Errorf("failed to publish change: %w", err)
-					}
+					changeset = append(changeset, events.FieldChange{
+						Field:         "created_at",
+						PreviousValue: pv_created_at,
+						CurrentValue:  cv_created_at,
+					})
+				}
 
-					return retValue, nil
-				})
-			},
-			ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne,
-		),
+				cv_updated_at := ""
+				updated_at, ok := m.UpdatedAt()
 
-		// Delete Hook
-		hook.On(
-			func(next ent.Mutator) ent.Mutator {
-				return hook.PortFunc(func(ctx context.Context, m *generated.PortMutation) (ent.Value, error) {
-					additionalSubjects := []gidx.PrefixedID{}
-					relationships := []events.AuthRelationshipRelation{}
-
-					objID, ok := m.ID()
-					if !ok {
-						return nil, fmt.Errorf("object doesn't have an id %s", objID)
-					}
-
-					dbObj, err := m.Client().Port.Query().WithLoadBalancer().Where(port.IDEQ(objID)).Only(ctx)
-					if err != nil {
-						return nil, fmt.Errorf("failed to load object to get values for event, err %w", err)
-					}
-
-					// Ensure we have additional relevant subjects in the event msg
-					additionalSubjects = append(additionalSubjects, dbObj.LoadBalancerID)
-					additionalSubjects = append(additionalSubjects, dbObj.Edges.LoadBalancer.LocationID)
-					additionalSubjects = append(additionalSubjects, dbObj.Edges.LoadBalancer.OwnerID)
-					additionalSubjects = append(additionalSubjects, dbObj.Edges.LoadBalancer.ProviderID)
-
-					// we have all the info we need, now complete the mutation before we process the event
-					retValue, err := next.Mutate(ctx, m)
-					if err != nil {
-						return retValue, err
-					}
-
-					if len(relationships) != 0 {
-						if err := permissions.DeleteAuthRelationships(ctx, "load-balancer-port", objID, relationships...); err != nil {
-							return nil, fmt.Errorf("relationship request failed with error: %w", err)
+				if ok {
+					cv_updated_at = updated_at.Format(time.RFC3339)
+					pv_updated_at := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldUpdatedAt(ctx)
+						if err != nil {
+							pv_updated_at = "<unknown>"
+						} else {
+							pv_updated_at = ov.Format(time.RFC3339)
 						}
 					}
 
-					msg := events.ChangeMessage{
-						EventType:            eventType(m.Op()),
-						SubjectID:            objID,
-						AdditionalSubjectIDs: additionalSubjects,
-						Timestamp:            time.Now().UTC(),
+					changeset = append(changeset, events.FieldChange{
+						Field:         "updated_at",
+						PreviousValue: pv_updated_at,
+						CurrentValue:  cv_updated_at,
+					})
+				}
+
+				cv_name := ""
+				name, ok := m.Name()
+
+				if ok {
+					cv_name = fmt.Sprintf("%s", fmt.Sprint(name))
+					pv_name := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldName(ctx)
+						if err != nil {
+							pv_name = "<unknown>"
+						} else {
+							pv_name = fmt.Sprintf("%s", fmt.Sprint(ov))
+						}
 					}
 
-					if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer-port", msg); err != nil {
-						return nil, fmt.Errorf("failed to publish change: %w", err)
+					changeset = append(changeset, events.FieldChange{
+						Field:         "name",
+						PreviousValue: pv_name,
+						CurrentValue:  cv_name,
+					})
+				}
+
+				cv_protocol := ""
+				protocol, ok := m.Protocol()
+
+				if ok {
+					cv_protocol = fmt.Sprintf("%s", fmt.Sprint(protocol))
+					pv_protocol := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldProtocol(ctx)
+						if err != nil {
+							pv_protocol = "<unknown>"
+						} else {
+							pv_protocol = fmt.Sprintf("%s", fmt.Sprint(ov))
+						}
 					}
 
-					return retValue, nil
+					changeset = append(changeset, events.FieldChange{
+						Field:         "protocol",
+						PreviousValue: pv_protocol,
+						CurrentValue:  cv_protocol,
+					})
+				}
+
+				cv_owner_id := ""
+				owner_id, ok := m.OwnerID()
+				if !ok && !m.Op().Is(ent.OpCreate) {
+					// since we are doing an update or delete and these fields didn't change, load the "old" value
+					owner_id, err = m.OldOwnerID(ctx)
+					if err != nil {
+						return nil, err
+					}
+				}
+				additionalSubjects = append(additionalSubjects, owner_id)
+
+				relationships = append(relationships, events.AuthRelationshipRelation{
+					Relation:  "owner",
+					SubjectID: owner_id,
 				})
-			},
-			ent.OpDelete|ent.OpDeleteOne,
+
+				if ok {
+					cv_owner_id = fmt.Sprintf("%s", fmt.Sprint(owner_id))
+					pv_owner_id := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldOwnerID(ctx)
+						if err != nil {
+							pv_owner_id = "<unknown>"
+						} else {
+							pv_owner_id = fmt.Sprintf("%s", fmt.Sprint(ov))
+						}
+					}
+
+					changeset = append(changeset, events.FieldChange{
+						Field:         "owner_id",
+						PreviousValue: pv_owner_id,
+						CurrentValue:  cv_owner_id,
+					})
+				}
+
+				msg := events.ChangeMessage{
+					EventType:            eventType(m.Op()),
+					SubjectID:            objID,
+					AdditionalSubjectIDs: additionalSubjects,
+					Timestamp:            time.Now().UTC(),
+					FieldChanges:         changeset,
+				}
+
+				// complete the mutation before we process the event
+				retValue, err := next.Mutate(ctx, m)
+				if err != nil {
+					return retValue, err
+				}
+
+				// Ensure we have additional relevant subjects in the msg
+				addSubjPorts, err := m.Client().Port.Query().WithLoadBalancer().WithPools(func(q *generated.PoolQuery) {
+					q.WithOrigins()
+				}).Where(port.HasPoolsWith(pool.IDEQ(objID))).All(ctx)
+				if err == nil {
+					for _, port := range addSubjPorts {
+						for _, pool := range port.Edges.Pools {
+							for _, origin := range pool.Edges.Origins {
+								if !slices.Contains(msg.AdditionalSubjectIDs, origin.ID) {
+									msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, origin.ID)
+								}
+							}
+						}
+
+						if !slices.Contains(msg.AdditionalSubjectIDs, port.ID) && objID != port.ID {
+							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.ID)
+						}
+
+						if !slices.Contains(msg.AdditionalSubjectIDs, port.LoadBalancerID) {
+							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.LoadBalancerID)
+						}
+
+						if !slices.Contains(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.LocationID) {
+							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.LocationID)
+						}
+
+						if !slices.Contains(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.ProviderID) {
+							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, port.Edges.LoadBalancer.ProviderID)
+						}
+					}
+				}
+
+				if len(relationships) != 0 && eventType(m.Op()) == string(events.CreateChangeType) {
+					if err := permissions.CreateAuthRelationships(ctx, "load-balancer-pool", objID, relationships...); err != nil {
+						return nil, fmt.Errorf("relationship request failed with error: %w", err)
+					}
+				}
+
+				if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer-pool", msg); err != nil {
+					return nil, fmt.Errorf("failed to publish change: %w", err)
+				}
+
+				return retValue, nil
+			})
+		},
+		ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne,
+	)
+
+	// Delete Hook
+	dhook := hook.On(
+		func(next ent.Mutator) ent.Mutator {
+			return hook.PoolFunc(func(ctx context.Context, m *generated.PoolMutation) (ent.Value, error) {
+				additionalSubjects := []gidx.PrefixedID{}
+				relationships := []events.AuthRelationshipRelation{}
+
+				objID, ok := m.ID()
+				if !ok {
+					return nil, fmt.Errorf("object doesn't have an id %s", objID)
+				}
+
+				dbObj, err := m.Client().Pool.Get(ctx, objID)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load object to get values for event, err %w", err)
+				}
+
+				additionalSubjects = append(additionalSubjects, dbObj.OwnerID)
+
+				// Ensure we have additional relevant subjects in the msg
+				addSubjPorts, err := m.Client().Port.Query().WithLoadBalancer().Where(port.HasPoolsWith(pool.IDEQ(objID))).All(ctx)
+				if err == nil {
+					for _, port := range addSubjPorts {
+						if !slices.Contains(additionalSubjects, port.Edges.LoadBalancer.LocationID) {
+							additionalSubjects = append(additionalSubjects, port.Edges.LoadBalancer.LocationID)
+						}
+
+						if !slices.Contains(additionalSubjects, port.Edges.LoadBalancer.ProviderID) {
+							additionalSubjects = append(additionalSubjects, port.Edges.LoadBalancer.ProviderID)
+						}
+
+						if !slices.Contains(additionalSubjects, port.LoadBalancerID) {
+							additionalSubjects = append(additionalSubjects, port.LoadBalancerID)
+						}
+					}
+				}
+
+				relationships = append(relationships, events.AuthRelationshipRelation{
+					Relation:  "owner",
+					SubjectID: dbObj.OwnerID,
+				})
+
+				// we have all the info we need, now complete the mutation before we process the event
+				retValue, err := next.Mutate(ctx, m)
+				if err != nil {
+					return retValue, err
+				}
+
+				if len(relationships) != 0 {
+					if err := permissions.DeleteAuthRelationships(ctx, "load-balancer-pool", objID, relationships...); err != nil {
+						return nil, fmt.Errorf("relationship request failed with error: %w", err)
+					}
+				}
+
+				msg := events.ChangeMessage{
+					EventType:            string(events.DeleteChangeType),
+					SubjectID:            objID,
+					AdditionalSubjectIDs: additionalSubjects,
+					Timestamp:            time.Now().UTC(),
+				}
+
+				if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer-pool", msg); err != nil {
+					return nil, fmt.Errorf("failed to publish change: %w", err)
+				}
+
+				return retValue, nil
+			})
+		},
+		ent.OpDelete|ent.OpDeleteOne,
+	)
+	// }
+	// only trigger create/update hook when the deleted_at field is not set
+	cuhook = hook.If(
+		cuhook,
+		hook.Not(
+			hook.And(
+				hook.Or(
+					hook.HasOp(ent.OpUpdate),
+					hook.HasOp(ent.OpUpdateOne),
+				),
+				hook.HasFields("deleted_at"),
+			),
 		),
-	}
+	)
+
+	// TODO: should we not trigger an event when something is permanently deleted?
+	//       should this be a different type of message?
+
+	return []ent.Hook{cuhook, dhook}
+}
+
+func PortHooks() []ent.Hook {
+	// return []ent.Hook{
+	cuhook := hook.On(
+		func(next ent.Mutator) ent.Mutator {
+			return hook.PortFunc(func(ctx context.Context, m *generated.PortMutation) (ent.Value, error) {
+				var err error
+				additionalSubjects := []gidx.PrefixedID{}
+				relationships := []events.AuthRelationshipRelation{}
+
+				objID, ok := m.ID()
+				if !ok {
+					return nil, fmt.Errorf("object doesn't have an id %s", objID)
+				}
+
+				changeset := []events.FieldChange{}
+				cv_created_at := ""
+				created_at, ok := m.CreatedAt()
+
+				if ok {
+					cv_created_at = created_at.Format(time.RFC3339)
+					pv_created_at := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldCreatedAt(ctx)
+						if err != nil {
+							pv_created_at = "<unknown>"
+						} else {
+							pv_created_at = ov.Format(time.RFC3339)
+						}
+					}
+
+					changeset = append(changeset, events.FieldChange{
+						Field:         "created_at",
+						PreviousValue: pv_created_at,
+						CurrentValue:  cv_created_at,
+					})
+				}
+
+				cv_updated_at := ""
+				updated_at, ok := m.UpdatedAt()
+
+				if ok {
+					cv_updated_at = updated_at.Format(time.RFC3339)
+					pv_updated_at := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldUpdatedAt(ctx)
+						if err != nil {
+							pv_updated_at = "<unknown>"
+						} else {
+							pv_updated_at = ov.Format(time.RFC3339)
+						}
+					}
+
+					changeset = append(changeset, events.FieldChange{
+						Field:         "updated_at",
+						PreviousValue: pv_updated_at,
+						CurrentValue:  cv_updated_at,
+					})
+				}
+
+				cv_number := ""
+				number, ok := m.Number()
+
+				if ok {
+					cv_number = fmt.Sprintf("%s", fmt.Sprint(number))
+					pv_number := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldNumber(ctx)
+						if err != nil {
+							pv_number = "<unknown>"
+						} else {
+							pv_number = fmt.Sprintf("%s", fmt.Sprint(ov))
+						}
+					}
+
+					changeset = append(changeset, events.FieldChange{
+						Field:         "number",
+						PreviousValue: pv_number,
+						CurrentValue:  cv_number,
+					})
+				}
+
+				cv_name := ""
+				name, ok := m.Name()
+
+				if ok {
+					cv_name = fmt.Sprintf("%s", fmt.Sprint(name))
+					pv_name := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldName(ctx)
+						if err != nil {
+							pv_name = "<unknown>"
+						} else {
+							pv_name = fmt.Sprintf("%s", fmt.Sprint(ov))
+						}
+					}
+
+					changeset = append(changeset, events.FieldChange{
+						Field:         "name",
+						PreviousValue: pv_name,
+						CurrentValue:  cv_name,
+					})
+				}
+
+				cv_load_balancer_id := ""
+				load_balancer_id, ok := m.LoadBalancerID()
+				if ok {
+					cv_load_balancer_id = fmt.Sprintf("%s", fmt.Sprint(load_balancer_id))
+					pv_load_balancer_id := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldLoadBalancerID(ctx)
+						if err != nil {
+							pv_load_balancer_id = "<unknown>"
+						} else {
+							pv_load_balancer_id = fmt.Sprintf("%s", fmt.Sprint(ov))
+						}
+					}
+
+					changeset = append(changeset, events.FieldChange{
+						Field:         "load_balancer_id",
+						PreviousValue: pv_load_balancer_id,
+						CurrentValue:  cv_load_balancer_id,
+					})
+				}
+
+				msg := events.ChangeMessage{
+					EventType:            eventType(m.Op()),
+					SubjectID:            objID,
+					AdditionalSubjectIDs: additionalSubjects,
+					Timestamp:            time.Now().UTC(),
+					FieldChanges:         changeset,
+				}
+
+				// complete the mutation before we process the event
+				retValue, err := next.Mutate(ctx, m)
+				if err != nil {
+					return retValue, err
+				}
+
+				// Ensure we have additional relevant subjects in the event msg
+				addSubjPort, err := m.Client().Port.Query().WithPools().WithLoadBalancer().Where(port.IDEQ(objID)).Only(ctx)
+				if err == nil {
+					if !slices.Contains(msg.AdditionalSubjectIDs, addSubjPort.LoadBalancerID) {
+						msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, addSubjPort.LoadBalancerID)
+					}
+
+					if !slices.Contains(msg.AdditionalSubjectIDs, addSubjPort.Edges.LoadBalancer.LocationID) {
+						msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, addSubjPort.Edges.LoadBalancer.LocationID)
+					}
+
+					if !slices.Contains(msg.AdditionalSubjectIDs, addSubjPort.Edges.LoadBalancer.OwnerID) {
+						msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, addSubjPort.Edges.LoadBalancer.OwnerID)
+					}
+
+					if !slices.Contains(msg.AdditionalSubjectIDs, addSubjPort.Edges.LoadBalancer.ProviderID) {
+						msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, addSubjPort.Edges.LoadBalancer.ProviderID)
+					}
+
+					for _, pool := range addSubjPort.Edges.Pools {
+						if !slices.Contains(msg.AdditionalSubjectIDs, pool.ID) {
+							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, pool.ID)
+						}
+
+						if !slices.Contains(msg.AdditionalSubjectIDs, pool.OwnerID) {
+							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, pool.OwnerID)
+						}
+					}
+				}
+
+				if len(relationships) != 0 && eventType(m.Op()) == string(events.CreateChangeType) {
+					if err := permissions.CreateAuthRelationships(ctx, "load-balancer-port", objID, relationships...); err != nil {
+						return nil, fmt.Errorf("relationship request failed with error: %w", err)
+					}
+				}
+
+				if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer-port", msg); err != nil {
+					return nil, fmt.Errorf("failed to publish change: %w", err)
+				}
+
+				return retValue, nil
+			})
+		},
+		ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne,
+	)
+
+	// Delete Hook
+	dhook := hook.On(
+		func(next ent.Mutator) ent.Mutator {
+			return hook.PortFunc(func(ctx context.Context, m *generated.PortMutation) (ent.Value, error) {
+				additionalSubjects := []gidx.PrefixedID{}
+				relationships := []events.AuthRelationshipRelation{}
+
+				objID, ok := m.ID()
+				if !ok {
+					return nil, fmt.Errorf("object doesn't have an id %s", objID)
+				}
+
+				dbObj, err := m.Client().Port.Query().WithLoadBalancer().Where(port.IDEQ(objID)).Only(ctx)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load object to get values for event, err %w", err)
+				}
+
+				// Ensure we have additional relevant subjects in the event msg
+				additionalSubjects = append(additionalSubjects, dbObj.LoadBalancerID)
+				additionalSubjects = append(additionalSubjects, dbObj.Edges.LoadBalancer.LocationID)
+				additionalSubjects = append(additionalSubjects, dbObj.Edges.LoadBalancer.OwnerID)
+				additionalSubjects = append(additionalSubjects, dbObj.Edges.LoadBalancer.ProviderID)
+
+				// we have all the info we need, now complete the mutation before we process the event
+				retValue, err := next.Mutate(ctx, m)
+				if err != nil {
+					return retValue, err
+				}
+
+				if len(relationships) != 0 {
+					if err := permissions.DeleteAuthRelationships(ctx, "load-balancer-port", objID, relationships...); err != nil {
+						return nil, fmt.Errorf("relationship request failed with error: %w", err)
+					}
+				}
+
+				msg := events.ChangeMessage{
+					EventType:            string(events.DeleteChangeType),
+					SubjectID:            objID,
+					AdditionalSubjectIDs: additionalSubjects,
+					Timestamp:            time.Now().UTC(),
+				}
+
+				if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer-port", msg); err != nil {
+					return nil, fmt.Errorf("failed to publish change: %w", err)
+				}
+
+				return retValue, nil
+			})
+		},
+		ent.OpDelete|ent.OpDeleteOne,
+	)
+	// }
+	// only trigger create/update hook when the deleted_at field is not set
+	cuhook = hook.If(
+		cuhook,
+		hook.Not(
+			hook.And(
+				hook.Or(
+					hook.HasOp(ent.OpUpdate),
+					hook.HasOp(ent.OpUpdateOne),
+				),
+				hook.HasFields("deleted_at"),
+			),
+		),
+	)
+
+	// TODO: should we not trigger an event when something is permanently deleted?
+	//       should this be a different type of message?
+
+	return []ent.Hook{cuhook, dhook}
 }
 
 // PubsubHooks registers our hooks with the ent client

--- a/internal/manualhooks/hooks.go
+++ b/internal/manualhooks/hooks.go
@@ -23,265 +23,280 @@ import (
 )
 
 func LoadBalancerHooks() []ent.Hook {
-	return []ent.Hook{
-		hook.On(
-			func(next ent.Mutator) ent.Mutator {
-				return hook.LoadBalancerFunc(func(ctx context.Context, m *generated.LoadBalancerMutation) (ent.Value, error) {
-					var err error
-					additionalSubjects := []gidx.PrefixedID{}
-					relationships := []events.AuthRelationshipRelation{}
+	// return []ent.Hook{
+	cuhook := hook.On(
+		func(next ent.Mutator) ent.Mutator {
+			return hook.LoadBalancerFunc(func(ctx context.Context, m *generated.LoadBalancerMutation) (ent.Value, error) {
+				var err error
+				additionalSubjects := []gidx.PrefixedID{}
+				relationships := []events.AuthRelationshipRelation{}
 
-					objID, ok := m.ID()
-					if !ok {
-						return nil, fmt.Errorf("object doesn't have an id %s", objID)
-					}
+				objID, ok := m.ID()
+				if !ok {
+					return nil, fmt.Errorf("object doesn't have an id %s", objID)
+				}
 
-					additionalSubjects = append(additionalSubjects, objID)
+				additionalSubjects = append(additionalSubjects, objID)
 
-					changeset := []events.FieldChange{}
-					cv_created_at := ""
-					created_at, ok := m.CreatedAt()
+				changeset := []events.FieldChange{}
+				cv_created_at := ""
+				created_at, ok := m.CreatedAt()
 
-					if ok {
-						cv_created_at = created_at.Format(time.RFC3339)
-						pv_created_at := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldCreatedAt(ctx)
-							if err != nil {
-								pv_created_at = "<unknown>"
-							} else {
-								pv_created_at = ov.Format(time.RFC3339)
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "created_at",
-							PreviousValue: pv_created_at,
-							CurrentValue:  cv_created_at,
-						})
-					}
-
-					cv_updated_at := ""
-					updated_at, ok := m.UpdatedAt()
-
-					if ok {
-						cv_updated_at = updated_at.Format(time.RFC3339)
-						pv_updated_at := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldUpdatedAt(ctx)
-							if err != nil {
-								pv_updated_at = "<unknown>"
-							} else {
-								pv_updated_at = ov.Format(time.RFC3339)
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "updated_at",
-							PreviousValue: pv_updated_at,
-							CurrentValue:  cv_updated_at,
-						})
-					}
-
-					cv_name := ""
-					name, ok := m.Name()
-
-					if ok {
-						cv_name = fmt.Sprintf("%s", fmt.Sprint(name))
-						pv_name := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldName(ctx)
-							if err != nil {
-								pv_name = "<unknown>"
-							} else {
-								pv_name = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "name",
-							PreviousValue: pv_name,
-							CurrentValue:  cv_name,
-						})
-					}
-
-					cv_owner_id := ""
-					owner_id, ok := m.OwnerID()
-					if !ok && !m.Op().Is(ent.OpCreate) {
-						// since we are doing an update or delete and these fields didn't change, load the "old" value
-						owner_id, err = m.OldOwnerID(ctx)
+				if ok {
+					cv_created_at = created_at.Format(time.RFC3339)
+					pv_created_at := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldCreatedAt(ctx)
 						if err != nil {
-							return nil, err
+							pv_created_at = "<unknown>"
+						} else {
+							pv_created_at = ov.Format(time.RFC3339)
 						}
 					}
-					additionalSubjects = append(additionalSubjects, owner_id)
 
-					relationships = append(relationships, events.AuthRelationshipRelation{
-						Relation:  "owner",
-						SubjectID: owner_id,
+					changeset = append(changeset, events.FieldChange{
+						Field:         "created_at",
+						PreviousValue: pv_created_at,
+						CurrentValue:  cv_created_at,
 					})
+				}
 
-					if ok {
-						cv_owner_id = fmt.Sprintf("%s", fmt.Sprint(owner_id))
-						pv_owner_id := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldOwnerID(ctx)
-							if err != nil {
-								pv_owner_id = "<unknown>"
-							} else {
-								pv_owner_id = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
+				cv_updated_at := ""
+				updated_at, ok := m.UpdatedAt()
+
+				if ok {
+					cv_updated_at = updated_at.Format(time.RFC3339)
+					pv_updated_at := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldUpdatedAt(ctx)
+						if err != nil {
+							pv_updated_at = "<unknown>"
+						} else {
+							pv_updated_at = ov.Format(time.RFC3339)
 						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "owner_id",
-							PreviousValue: pv_owner_id,
-							CurrentValue:  cv_owner_id,
-						})
 					}
 
-					cv_location_id := ""
-					location_id, ok := m.LocationID()
+					changeset = append(changeset, events.FieldChange{
+						Field:         "updated_at",
+						PreviousValue: pv_updated_at,
+						CurrentValue:  cv_updated_at,
+					})
+				}
 
-					if ok {
-						cv_location_id = fmt.Sprintf("%s", fmt.Sprint(location_id))
-						pv_location_id := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldLocationID(ctx)
-							if err != nil {
-								pv_location_id = "<unknown>"
-							} else {
-								pv_location_id = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
+				cv_name := ""
+				name, ok := m.Name()
+
+				if ok {
+					cv_name = fmt.Sprintf("%s", fmt.Sprint(name))
+					pv_name := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldName(ctx)
+						if err != nil {
+							pv_name = "<unknown>"
+						} else {
+							pv_name = fmt.Sprintf("%s", fmt.Sprint(ov))
 						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "location_id",
-							PreviousValue: pv_location_id,
-							CurrentValue:  cv_location_id,
-						})
 					}
 
-					cv_provider_id := ""
-					provider_id, ok := m.ProviderID()
+					changeset = append(changeset, events.FieldChange{
+						Field:         "name",
+						PreviousValue: pv_name,
+						CurrentValue:  cv_name,
+					})
+				}
 
-					if ok {
-						cv_provider_id = fmt.Sprintf("%s", fmt.Sprint(provider_id))
-						pv_provider_id := ""
-						if !m.Op().Is(ent.OpCreate) {
-							ov, err := m.OldProviderID(ctx)
-							if err != nil {
-								pv_provider_id = "<unknown>"
-							} else {
-								pv_provider_id = fmt.Sprintf("%s", fmt.Sprint(ov))
-							}
-						}
-
-						changeset = append(changeset, events.FieldChange{
-							Field:         "provider_id",
-							PreviousValue: pv_provider_id,
-							CurrentValue:  cv_provider_id,
-						})
-					}
-
-					msg := events.ChangeMessage{
-						EventType:            eventType(m.Op()),
-						SubjectID:            objID,
-						AdditionalSubjectIDs: additionalSubjects,
-						Timestamp:            time.Now().UTC(),
-						FieldChanges:         changeset,
-					}
-
-					// complete the mutation before we process the event
-					retValue, err := next.Mutate(ctx, m)
+				cv_owner_id := ""
+				owner_id, ok := m.OwnerID()
+				if !ok && !m.Op().Is(ent.OpCreate) {
+					// since we are doing an update or delete and these fields didn't change, load the "old" value
+					owner_id, err = m.OldOwnerID(ctx)
 					if err != nil {
-						return retValue, err
+						return nil, err
 					}
+				}
+				additionalSubjects = append(additionalSubjects, owner_id)
 
-					// Ensure we have additional relevant subjects in the msg
-					lb, err := m.Client().LoadBalancer.Query().WithPorts().Where(loadbalancer.IDEQ(objID)).Only(ctx)
-					if err == nil {
-						if !slices.Contains(msg.AdditionalSubjectIDs, lb.LocationID) {
-							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, lb.LocationID)
-						}
-
-						if !slices.Contains(msg.AdditionalSubjectIDs, lb.ProviderID) {
-							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, lb.ProviderID)
-						}
-
-						for _, p := range lb.Edges.Ports {
-							if !slices.Contains(msg.AdditionalSubjectIDs, p.ID) {
-								msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, p.ID)
-							}
-						}
-					}
-
-					if len(relationships) != 0 && eventType(m.Op()) == string(events.CreateChangeType) {
-						if err := permissions.CreateAuthRelationships(ctx, "load-balancer", objID, relationships...); err != nil {
-							return nil, fmt.Errorf("relationship request failed with error: %w", err)
-						}
-					}
-
-					if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer", msg); err != nil {
-						return nil, fmt.Errorf("failed to publish change: %w", err)
-					}
-
-					return retValue, nil
+				relationships = append(relationships, events.AuthRelationshipRelation{
+					Relation:  "owner",
+					SubjectID: owner_id,
 				})
-			},
-			ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne,
-		),
 
-		// Delete Hook
-		hook.On(
-			func(next ent.Mutator) ent.Mutator {
-				return hook.LoadBalancerFunc(func(ctx context.Context, m *generated.LoadBalancerMutation) (ent.Value, error) {
-					additionalSubjects := []gidx.PrefixedID{}
-					relationships := []events.AuthRelationshipRelation{}
-
-					objID, ok := m.ID()
-					if !ok {
-						return nil, fmt.Errorf("object doesn't have an id %s", objID)
-					}
-
-					dbObj, err := m.Client().LoadBalancer.Get(ctx, objID)
-					if err != nil {
-						return nil, fmt.Errorf("failed to load object to get values for event, err %w", err)
-					}
-
-					additionalSubjects = append(additionalSubjects, dbObj.OwnerID)
-					additionalSubjects = append(additionalSubjects, dbObj.LocationID)
-					additionalSubjects = append(additionalSubjects, dbObj.ProviderID)
-
-					// we have all the info we need, now complete the mutation before we process the event
-					retValue, err := next.Mutate(ctx, m)
-					if err != nil {
-						return retValue, err
-					}
-
-					if len(relationships) != 0 {
-						if err := permissions.DeleteAuthRelationships(ctx, "load-balancer", objID, relationships...); err != nil {
-							return nil, fmt.Errorf("relationship request failed with error: %w", err)
+				if ok {
+					cv_owner_id = fmt.Sprintf("%s", fmt.Sprint(owner_id))
+					pv_owner_id := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldOwnerID(ctx)
+						if err != nil {
+							pv_owner_id = "<unknown>"
+						} else {
+							pv_owner_id = fmt.Sprintf("%s", fmt.Sprint(ov))
 						}
 					}
 
-					msg := events.ChangeMessage{
-						EventType:            eventType(m.Op()),
-						SubjectID:            objID,
-						AdditionalSubjectIDs: additionalSubjects,
-						Timestamp:            time.Now().UTC(),
+					changeset = append(changeset, events.FieldChange{
+						Field:         "owner_id",
+						PreviousValue: pv_owner_id,
+						CurrentValue:  cv_owner_id,
+					})
+				}
+
+				cv_location_id := ""
+				location_id, ok := m.LocationID()
+
+				if ok {
+					cv_location_id = fmt.Sprintf("%s", fmt.Sprint(location_id))
+					pv_location_id := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldLocationID(ctx)
+						if err != nil {
+							pv_location_id = "<unknown>"
+						} else {
+							pv_location_id = fmt.Sprintf("%s", fmt.Sprint(ov))
+						}
 					}
 
-					if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer", msg); err != nil {
-						return nil, fmt.Errorf("failed to publish change: %w", err)
+					changeset = append(changeset, events.FieldChange{
+						Field:         "location_id",
+						PreviousValue: pv_location_id,
+						CurrentValue:  cv_location_id,
+					})
+				}
+
+				cv_provider_id := ""
+				provider_id, ok := m.ProviderID()
+
+				if ok {
+					cv_provider_id = fmt.Sprintf("%s", fmt.Sprint(provider_id))
+					pv_provider_id := ""
+					if !m.Op().Is(ent.OpCreate) {
+						ov, err := m.OldProviderID(ctx)
+						if err != nil {
+							pv_provider_id = "<unknown>"
+						} else {
+							pv_provider_id = fmt.Sprintf("%s", fmt.Sprint(ov))
+						}
 					}
 
-					return retValue, nil
-				})
-			},
-			ent.OpDelete|ent.OpDeleteOne,
+					changeset = append(changeset, events.FieldChange{
+						Field:         "provider_id",
+						PreviousValue: pv_provider_id,
+						CurrentValue:  cv_provider_id,
+					})
+				}
+
+				msg := events.ChangeMessage{
+					EventType:            eventType(m.Op()),
+					SubjectID:            objID,
+					AdditionalSubjectIDs: additionalSubjects,
+					Timestamp:            time.Now().UTC(),
+					FieldChanges:         changeset,
+				}
+
+				// complete the mutation before we process the event
+				retValue, err := next.Mutate(ctx, m)
+				if err != nil {
+					return retValue, err
+				}
+
+				// Ensure we have additional relevant subjects in the msg
+				lb, err := m.Client().LoadBalancer.Query().WithPorts().Where(loadbalancer.IDEQ(objID)).Only(ctx)
+				if err == nil {
+					if !slices.Contains(msg.AdditionalSubjectIDs, lb.LocationID) {
+						msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, lb.LocationID)
+					}
+
+					if !slices.Contains(msg.AdditionalSubjectIDs, lb.ProviderID) {
+						msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, lb.ProviderID)
+					}
+
+					for _, p := range lb.Edges.Ports {
+						if !slices.Contains(msg.AdditionalSubjectIDs, p.ID) {
+							msg.AdditionalSubjectIDs = append(msg.AdditionalSubjectIDs, p.ID)
+						}
+					}
+				}
+
+				if len(relationships) != 0 && eventType(m.Op()) == string(events.CreateChangeType) {
+					if err := permissions.CreateAuthRelationships(ctx, "load-balancer", objID, relationships...); err != nil {
+						return nil, fmt.Errorf("relationship request failed with error: %w", err)
+					}
+				}
+
+				if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer", msg); err != nil {
+					return nil, fmt.Errorf("failed to publish change: %w", err)
+				}
+
+				return retValue, nil
+			})
+		},
+		ent.OpCreate|ent.OpUpdate|ent.OpUpdateOne,
+	)
+
+	// Delete Hook
+	dhook := hook.On(
+		func(next ent.Mutator) ent.Mutator {
+			return hook.LoadBalancerFunc(func(ctx context.Context, m *generated.LoadBalancerMutation) (ent.Value, error) {
+				additionalSubjects := []gidx.PrefixedID{}
+				relationships := []events.AuthRelationshipRelation{}
+
+				objID, ok := m.ID()
+				if !ok {
+					return nil, fmt.Errorf("object doesn't have an id %s", objID)
+				}
+
+				dbObj, err := m.Client().LoadBalancer.Get(ctx, objID)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load object to get values for event, err %w", err)
+				}
+
+				additionalSubjects = append(additionalSubjects, dbObj.OwnerID)
+				additionalSubjects = append(additionalSubjects, dbObj.LocationID)
+				additionalSubjects = append(additionalSubjects, dbObj.ProviderID)
+
+				// we have all the info we need, now complete the mutation before we process the event
+				retValue, err := next.Mutate(ctx, m)
+				if err != nil {
+					return retValue, err
+				}
+
+				if len(relationships) != 0 {
+					if err := permissions.DeleteAuthRelationships(ctx, "load-balancer", objID, relationships...); err != nil {
+						return nil, fmt.Errorf("relationship request failed with error: %w", err)
+					}
+				}
+
+				msg := events.ChangeMessage{
+					EventType:            eventType(m.Op()),
+					SubjectID:            objID,
+					AdditionalSubjectIDs: additionalSubjects,
+					Timestamp:            time.Now().UTC(),
+				}
+
+				if _, err := m.EventsPublisher.PublishChange(ctx, "load-balancer", msg); err != nil {
+					return nil, fmt.Errorf("failed to publish change: %w", err)
+				}
+
+				return retValue, nil
+			})
+		},
+		ent.OpDelete|ent.OpDeleteOne,
+	)
+	// }
+
+	cuhook = hook.If(
+		cuhook,
+		hook.Not(
+			hook.And(
+				hook.Or(
+					hook.HasOp(ent.OpUpdate),
+					hook.HasOp(ent.OpUpdateOne),
+				),
+				hook.HasFields("deleted_at"),
+			),
 		),
-	}
+	)
+
+	return []ent.Hook{cuhook, dhook}
 }
 
 func OriginHooks() []ent.Hook {

--- a/schema.graphql
+++ b/schema.graphql
@@ -146,6 +146,8 @@ type LoadBalancerOrigin implements Node @key(fields: "id") @prefixedID(prefix: "
 	id: ID!
 	createdAt: Time!
 	updatedAt: Time!
+	deletedAt: Time
+	deletedBy: String
 	createdBy: String
 	updatedBy: String
 	name: String!
@@ -193,6 +195,8 @@ input LoadBalancerOriginOrder {
 enum LoadBalancerOriginOrderField {
 	CREATED_AT
 	UPDATED_AT
+	DELETED_AT
+	DELETED_BY
 	CREATED_BY
 	UPDATED_BY
 	name
@@ -241,6 +245,33 @@ input LoadBalancerOriginWhereInput {
 	updatedAtGTE: Time
 	updatedAtLT: Time
 	updatedAtLTE: Time
+	"""deleted_at field predicates"""
+	deletedAt: Time
+	deletedAtNEQ: Time
+	deletedAtIn: [Time!]
+	deletedAtNotIn: [Time!]
+	deletedAtGT: Time
+	deletedAtGTE: Time
+	deletedAtLT: Time
+	deletedAtLTE: Time
+	deletedAtIsNil: Boolean
+	deletedAtNotNil: Boolean
+	"""deleted_by field predicates"""
+	deletedBy: String
+	deletedByNEQ: String
+	deletedByIn: [String!]
+	deletedByNotIn: [String!]
+	deletedByGT: String
+	deletedByGTE: String
+	deletedByLT: String
+	deletedByLTE: String
+	deletedByContains: String
+	deletedByHasPrefix: String
+	deletedByHasSuffix: String
+	deletedByIsNil: Boolean
+	deletedByNotNil: Boolean
+	deletedByEqualFold: String
+	deletedByContainsFold: String
 	"""created_by field predicates"""
 	createdBy: String
 	createdByNEQ: String
@@ -332,6 +363,8 @@ type LoadBalancerPool implements Node @key(fields: "id") @prefixedID(prefix: "lo
 	updatedAt: Time!
 	createdBy: String
 	updatedBy: String
+	deletedAt: Time
+	deletedBy: String
 	name: String!
 	protocol: LoadBalancerPoolProtocol!
 	ownerID: ID!
@@ -397,6 +430,8 @@ enum LoadBalancerPoolOrderField {
 	UPDATED_AT
 	CREATED_BY
 	UPDATED_BY
+	DELETED_AT
+	DELETED_BY
 	name
 	protocol
 }
@@ -477,6 +512,33 @@ input LoadBalancerPoolWhereInput {
 	updatedByNotNil: Boolean
 	updatedByEqualFold: String
 	updatedByContainsFold: String
+	"""deleted_at field predicates"""
+	deletedAt: Time
+	deletedAtNEQ: Time
+	deletedAtIn: [Time!]
+	deletedAtNotIn: [Time!]
+	deletedAtGT: Time
+	deletedAtGTE: Time
+	deletedAtLT: Time
+	deletedAtLTE: Time
+	deletedAtIsNil: Boolean
+	deletedAtNotNil: Boolean
+	"""deleted_by field predicates"""
+	deletedBy: String
+	deletedByNEQ: String
+	deletedByIn: [String!]
+	deletedByNotIn: [String!]
+	deletedByGT: String
+	deletedByGTE: String
+	deletedByLT: String
+	deletedByLTE: String
+	deletedByContains: String
+	deletedByHasPrefix: String
+	deletedByHasSuffix: String
+	deletedByIsNil: Boolean
+	deletedByNotNil: Boolean
+	deletedByEqualFold: String
+	deletedByContainsFold: String
 	"""name field predicates"""
 	name: String
 	nameNEQ: String
@@ -507,6 +569,8 @@ type LoadBalancerPort implements Node @key(fields: "id") @prefixedID(prefix: "lo
 	id: ID!
 	createdAt: Time!
 	updatedAt: Time!
+	deletedAt: Time
+	deletedBy: String
 	createdBy: String
 	updatedBy: String
 	number: Int!
@@ -552,6 +616,8 @@ input LoadBalancerPortOrder {
 enum LoadBalancerPortOrderField {
 	CREATED_AT
 	UPDATED_AT
+	DELETED_AT
+	DELETED_BY
 	CREATED_BY
 	UPDATED_BY
 	number
@@ -597,6 +663,33 @@ input LoadBalancerPortWhereInput {
 	updatedAtGTE: Time
 	updatedAtLT: Time
 	updatedAtLTE: Time
+	"""deleted_at field predicates"""
+	deletedAt: Time
+	deletedAtNEQ: Time
+	deletedAtIn: [Time!]
+	deletedAtNotIn: [Time!]
+	deletedAtGT: Time
+	deletedAtGTE: Time
+	deletedAtLT: Time
+	deletedAtLTE: Time
+	deletedAtIsNil: Boolean
+	deletedAtNotNil: Boolean
+	"""deleted_by field predicates"""
+	deletedBy: String
+	deletedByNEQ: String
+	deletedByIn: [String!]
+	deletedByNotIn: [String!]
+	deletedByGT: String
+	deletedByGTE: String
+	deletedByLT: String
+	deletedByLTE: String
+	deletedByContains: String
+	deletedByHasPrefix: String
+	deletedByHasSuffix: String
+	deletedByIsNil: Boolean
+	deletedByNotNil: Boolean
+	deletedByEqualFold: String
+	deletedByContainsFold: String
 	"""created_by field predicates"""
 	createdBy: String
 	createdByNEQ: String
@@ -664,6 +757,8 @@ type LoadBalancerProvider implements Node @key(fields: "id") @prefixedID(prefix:
 	id: ID!
 	createdAt: Time!
 	updatedAt: Time!
+	deletedAt: Time
+	deletedBy: String
 	createdBy: String
 	updatedBy: String
 	"""The name of the load balancer provider."""
@@ -728,6 +823,8 @@ enum LoadBalancerProviderOrderField {
 	ID
 	CREATED_AT
 	UPDATED_AT
+	DELETED_AT
+	DELETED_BY
 	CREATED_BY
 	UPDATED_BY
 	NAME
@@ -773,6 +870,33 @@ input LoadBalancerProviderWhereInput {
 	updatedAtGTE: Time
 	updatedAtLT: Time
 	updatedAtLTE: Time
+	"""deleted_at field predicates"""
+	deletedAt: Time
+	deletedAtNEQ: Time
+	deletedAtIn: [Time!]
+	deletedAtNotIn: [Time!]
+	deletedAtGT: Time
+	deletedAtGTE: Time
+	deletedAtLT: Time
+	deletedAtLTE: Time
+	deletedAtIsNil: Boolean
+	deletedAtNotNil: Boolean
+	"""deleted_by field predicates"""
+	deletedBy: String
+	deletedByNEQ: String
+	deletedByIn: [String!]
+	deletedByNotIn: [String!]
+	deletedByGT: String
+	deletedByGTE: String
+	deletedByLT: String
+	deletedByLTE: String
+	deletedByContains: String
+	deletedByHasPrefix: String
+	deletedByHasSuffix: String
+	deletedByIsNil: Boolean
+	deletedByNotNil: Boolean
+	deletedByEqualFold: String
+	deletedByContainsFold: String
 	"""created_by field predicates"""
 	createdBy: String
 	createdByNEQ: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -1178,6 +1178,11 @@ type Query {
 		"""The load balancer ID."""
 		id: ID!
 	): LoadBalancer!
+	"""Lookup a load balancer by ID."""
+	loadBalancerHistory(
+		"""The load balancer ID."""
+		id: ID!
+	): LoadBalancer!
 	"""Lookup a pool by ID."""
 	loadBalancerPool(
 		"""The pool ID."""

--- a/schema.graphql
+++ b/schema.graphql
@@ -67,6 +67,8 @@ type LoadBalancer implements Node & IPAddressable & MetadataNode @key(fields: "i
 	updatedAt: Time!
 	createdBy: String
 	updatedBy: String
+	deletedAt: Time
+	deletedBy: String
 	"""The name of the load balancer."""
 	name: String!
 	ports(
@@ -135,6 +137,8 @@ enum LoadBalancerOrderField {
 	UPDATED_AT
 	CREATED_BY
 	UPDATED_BY
+	DELETED_AT
+	DELETED_BY
 	NAME
 	OWNER
 }
@@ -891,6 +895,33 @@ input LoadBalancerWhereInput {
 	updatedByNotNil: Boolean
 	updatedByEqualFold: String
 	updatedByContainsFold: String
+	"""deleted_at field predicates"""
+	deletedAt: Time
+	deletedAtNEQ: Time
+	deletedAtIn: [Time!]
+	deletedAtNotIn: [Time!]
+	deletedAtGT: Time
+	deletedAtGTE: Time
+	deletedAtLT: Time
+	deletedAtLTE: Time
+	deletedAtIsNil: Boolean
+	deletedAtNotNil: Boolean
+	"""deleted_by field predicates"""
+	deletedBy: String
+	deletedByNEQ: String
+	deletedByIn: [String!]
+	deletedByNotIn: [String!]
+	deletedByGT: String
+	deletedByGTE: String
+	deletedByLT: String
+	deletedByLTE: String
+	deletedByContains: String
+	deletedByHasPrefix: String
+	deletedByHasSuffix: String
+	deletedByIsNil: Boolean
+	deletedByNotNil: Boolean
+	deletedByEqualFold: String
+	deletedByContainsFold: String
 	"""name field predicates"""
 	name: String
 	nameNEQ: String

--- a/schema/ent.graphql
+++ b/schema/ent.graphql
@@ -130,6 +130,8 @@ type LoadBalancerOrigin implements Node @key(fields: "id") @prefixedID(prefix: "
   id: ID!
   createdAt: Time!
   updatedAt: Time!
+  deletedAt: Time
+  deletedBy: String
   createdBy: String
   updatedBy: String
   name: String!
@@ -167,6 +169,8 @@ input LoadBalancerOriginOrder {
 enum LoadBalancerOriginOrderField {
   CREATED_AT
   UPDATED_AT
+  DELETED_AT
+  DELETED_BY
   CREATED_BY
   UPDATED_BY
   name
@@ -210,6 +214,33 @@ input LoadBalancerOriginWhereInput {
   updatedAtGTE: Time
   updatedAtLT: Time
   updatedAtLTE: Time
+  """deleted_at field predicates"""
+  deletedAt: Time
+  deletedAtNEQ: Time
+  deletedAtIn: [Time!]
+  deletedAtNotIn: [Time!]
+  deletedAtGT: Time
+  deletedAtGTE: Time
+  deletedAtLT: Time
+  deletedAtLTE: Time
+  deletedAtIsNil: Boolean
+  deletedAtNotNil: Boolean
+  """deleted_by field predicates"""
+  deletedBy: String
+  deletedByNEQ: String
+  deletedByIn: [String!]
+  deletedByNotIn: [String!]
+  deletedByGT: String
+  deletedByGTE: String
+  deletedByLT: String
+  deletedByLTE: String
+  deletedByContains: String
+  deletedByHasPrefix: String
+  deletedByHasSuffix: String
+  deletedByIsNil: Boolean
+  deletedByNotNil: Boolean
+  deletedByEqualFold: String
+  deletedByContainsFold: String
   """created_by field predicates"""
   createdBy: String
   createdByNEQ: String
@@ -301,6 +332,8 @@ type LoadBalancerPool implements Node @key(fields: "id") @prefixedID(prefix: "lo
   updatedAt: Time!
   createdBy: String
   updatedBy: String
+  deletedAt: Time
+  deletedBy: String
   name: String!
   protocol: LoadBalancerPoolProtocol!
   ownerID: ID!
@@ -354,6 +387,8 @@ enum LoadBalancerPoolOrderField {
   UPDATED_AT
   CREATED_BY
   UPDATED_BY
+  DELETED_AT
+  DELETED_BY
   name
   protocol
 }
@@ -429,6 +464,33 @@ input LoadBalancerPoolWhereInput {
   updatedByNotNil: Boolean
   updatedByEqualFold: String
   updatedByContainsFold: String
+  """deleted_at field predicates"""
+  deletedAt: Time
+  deletedAtNEQ: Time
+  deletedAtIn: [Time!]
+  deletedAtNotIn: [Time!]
+  deletedAtGT: Time
+  deletedAtGTE: Time
+  deletedAtLT: Time
+  deletedAtLTE: Time
+  deletedAtIsNil: Boolean
+  deletedAtNotNil: Boolean
+  """deleted_by field predicates"""
+  deletedBy: String
+  deletedByNEQ: String
+  deletedByIn: [String!]
+  deletedByNotIn: [String!]
+  deletedByGT: String
+  deletedByGTE: String
+  deletedByLT: String
+  deletedByLTE: String
+  deletedByContains: String
+  deletedByHasPrefix: String
+  deletedByHasSuffix: String
+  deletedByIsNil: Boolean
+  deletedByNotNil: Boolean
+  deletedByEqualFold: String
+  deletedByContainsFold: String
   """name field predicates"""
   name: String
   nameNEQ: String
@@ -459,6 +521,8 @@ type LoadBalancerPort implements Node @key(fields: "id") @prefixedID(prefix: "lo
   id: ID!
   createdAt: Time!
   updatedAt: Time!
+  deletedAt: Time
+  deletedBy: String
   createdBy: String
   updatedBy: String
   number: Int!
@@ -494,6 +558,8 @@ input LoadBalancerPortOrder {
 enum LoadBalancerPortOrderField {
   CREATED_AT
   UPDATED_AT
+  DELETED_AT
+  DELETED_BY
   CREATED_BY
   UPDATED_BY
   number
@@ -534,6 +600,33 @@ input LoadBalancerPortWhereInput {
   updatedAtGTE: Time
   updatedAtLT: Time
   updatedAtLTE: Time
+  """deleted_at field predicates"""
+  deletedAt: Time
+  deletedAtNEQ: Time
+  deletedAtIn: [Time!]
+  deletedAtNotIn: [Time!]
+  deletedAtGT: Time
+  deletedAtGTE: Time
+  deletedAtLT: Time
+  deletedAtLTE: Time
+  deletedAtIsNil: Boolean
+  deletedAtNotNil: Boolean
+  """deleted_by field predicates"""
+  deletedBy: String
+  deletedByNEQ: String
+  deletedByIn: [String!]
+  deletedByNotIn: [String!]
+  deletedByGT: String
+  deletedByGTE: String
+  deletedByLT: String
+  deletedByLTE: String
+  deletedByContains: String
+  deletedByHasPrefix: String
+  deletedByHasSuffix: String
+  deletedByIsNil: Boolean
+  deletedByNotNil: Boolean
+  deletedByEqualFold: String
+  deletedByContainsFold: String
   """created_by field predicates"""
   createdBy: String
   createdByNEQ: String
@@ -601,6 +694,8 @@ type LoadBalancerProvider implements Node @key(fields: "id") @prefixedID(prefix:
   id: ID!
   createdAt: Time!
   updatedAt: Time!
+  deletedAt: Time
+  deletedBy: String
   createdBy: String
   updatedBy: String
   """The name of the load balancer provider."""
@@ -653,6 +748,8 @@ enum LoadBalancerProviderOrderField {
   ID
   CREATED_AT
   UPDATED_AT
+  DELETED_AT
+  DELETED_BY
   CREATED_BY
   UPDATED_BY
   NAME
@@ -693,6 +790,33 @@ input LoadBalancerProviderWhereInput {
   updatedAtGTE: Time
   updatedAtLT: Time
   updatedAtLTE: Time
+  """deleted_at field predicates"""
+  deletedAt: Time
+  deletedAtNEQ: Time
+  deletedAtIn: [Time!]
+  deletedAtNotIn: [Time!]
+  deletedAtGT: Time
+  deletedAtGTE: Time
+  deletedAtLT: Time
+  deletedAtLTE: Time
+  deletedAtIsNil: Boolean
+  deletedAtNotNil: Boolean
+  """deleted_by field predicates"""
+  deletedBy: String
+  deletedByNEQ: String
+  deletedByIn: [String!]
+  deletedByNotIn: [String!]
+  deletedByGT: String
+  deletedByGTE: String
+  deletedByLT: String
+  deletedByLTE: String
+  deletedByContains: String
+  deletedByHasPrefix: String
+  deletedByHasSuffix: String
+  deletedByIsNil: Boolean
+  deletedByNotNil: Boolean
+  deletedByEqualFold: String
+  deletedByContainsFold: String
   """created_by field predicates"""
   createdBy: String
   createdByNEQ: String

--- a/schema/ent.graphql
+++ b/schema/ent.graphql
@@ -65,6 +65,8 @@ type LoadBalancer implements Node & IPAddressable & MetadataNode @key(fields: "i
   updatedAt: Time!
   createdBy: String
   updatedBy: String
+  deletedAt: Time
+  deletedBy: String
   """The name of the load balancer."""
   name: String!
   ports(
@@ -119,6 +121,8 @@ enum LoadBalancerOrderField {
   UPDATED_AT
   CREATED_BY
   UPDATED_BY
+  DELETED_AT
+  DELETED_BY
   NAME
   OWNER
 }
@@ -806,6 +810,33 @@ input LoadBalancerWhereInput {
   updatedByNotNil: Boolean
   updatedByEqualFold: String
   updatedByContainsFold: String
+  """deleted_at field predicates"""
+  deletedAt: Time
+  deletedAtNEQ: Time
+  deletedAtIn: [Time!]
+  deletedAtNotIn: [Time!]
+  deletedAtGT: Time
+  deletedAtGTE: Time
+  deletedAtLT: Time
+  deletedAtLTE: Time
+  deletedAtIsNil: Boolean
+  deletedAtNotNil: Boolean
+  """deleted_by field predicates"""
+  deletedBy: String
+  deletedByNEQ: String
+  deletedByIn: [String!]
+  deletedByNotIn: [String!]
+  deletedByGT: String
+  deletedByGTE: String
+  deletedByLT: String
+  deletedByLTE: String
+  deletedByContains: String
+  deletedByHasPrefix: String
+  deletedByHasSuffix: String
+  deletedByIsNil: Boolean
+  deletedByNotNil: Boolean
+  deletedByEqualFold: String
+  deletedByContainsFold: String
   """name field predicates"""
   name: String
   nameNEQ: String

--- a/schema/loadbalancer.graphql
+++ b/schema/loadbalancer.graphql
@@ -8,6 +8,15 @@ extend type Query {
     """
     id: ID!
   ): LoadBalancer!
+    """
+  Lookup a load balancer by ID.
+  """
+  loadBalancerHistory(
+    """
+    The load balancer ID.
+    """
+    id: ID!
+  ): LoadBalancer!
 }
 
 extend type Mutation {


### PR DESCRIPTION
This adds the initial implementation of soft deletes to the loadbalancerapi. With this PR, when a delete occurs the `deleted_at` and `deleted_by` columns are populated instead of the record being removed from the database. Now with these set, the API will know that if a user were attempt to query them normally, no records would be returned.

While this does turn the delete event -> update event, a delete NATS message is still generated as expected.

This also adds the `loadBalancerHistory` query which acts much the same as the `loadBalancer` query, however it sets the `SkipSoftDelete` key so that you can query a deleted LB. When permissions are enabled, this checks that the client has the appropriate permission before allowing the user to query deleted records. 

**TODO**: In a follow-up PR, we will add handling for cascading soft deletes (i.e. when a loadbalancer is soft deleted, the port will get soft-deleted, etc.)