### PR TITLE
Add initial GetLoadBalancerHistory to LB client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -64,6 +64,25 @@ func (c Client) GetLoadBalancer(ctx context.Context, id string) (*LoadBalancer, 
 	return &q.LoadBalancer, nil
 }
 
+// GetLoadBalancerHistory returns a load balancer by id
+func (c Client) GetLoadBalancerHistory(ctx context.Context, id string) (*LoadBalancerHistory, error) {
+	_, err := gidx.Parse(id)
+	if err != nil {
+		return nil, err
+	}
+
+	vars := map[string]interface{}{
+		"id": graphql.ID(id),
+	}
+
+	var q GetLoadBalancerHistory
+	if err := c.gqlCli.Query(ctx, &q, vars); err != nil {
+		return nil, translateGQLErr(err)
+	}
+
+	return &q.LoadBalancerHistory, nil
+}
+
 // NodeMetadata return the metadata-api subgraph node for a load balancer.
 // Once a load balancer is deleted, it is gone. There are no soft-deletes.
 // However, it's metadata remains to query via the node-resolver metadata-api subgraph.

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -71,13 +71,13 @@ type LoadBalancer struct {
 
 // LoadBalancerHistory is a struct that represents the LoadBalancer GraphQL type
 type LoadBalancerHistory struct {
-	ID          string       `graphql:"id" json:"id"`
-	Name        string       `graphql:"name" json:"name"`
-	Owner       OwnerNode    `graphql:"owner" json:"owner"`
-	Location    LocationNode `graphql:"location" json:"location"`
-	IPAddresses []IPAddress  `graphql:"IPAddresses" json:"IPAddresses"`
-	Metadata    Metadata     `graphql:"metadata" json:"metadata"`
-	Ports       Ports        `graphql:"ports" json:"ports"`
+	ID       string       `graphql:"id" json:"id"`
+	Name     string       `graphql:"name" json:"name"`
+	Owner    OwnerNode    `graphql:"owner" json:"owner"`
+	Location LocationNode `graphql:"location" json:"location"`
+	// IPAddresses []IPAddress  `graphql:"IPAddresses" json:"IPAddresses"`
+	// Metadata    Metadata     `graphql:"metadata" json:"metadata"`
+	Ports Ports `graphql:"ports" json:"ports"`
 }
 
 // GetLoadBalancer is a struct that represents the GetLoadBalancer GraphQL query

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -69,9 +69,25 @@ type LoadBalancer struct {
 	Ports       Ports        `graphql:"ports" json:"ports"`
 }
 
+// LoadBalancerHistory is a struct that represents the LoadBalancer GraphQL type
+type LoadBalancerHistory struct {
+	ID          string       `graphql:"id" json:"id"`
+	Name        string       `graphql:"name" json:"name"`
+	Owner       OwnerNode    `graphql:"owner" json:"owner"`
+	Location    LocationNode `graphql:"location" json:"location"`
+	IPAddresses []IPAddress  `graphql:"IPAddresses" json:"IPAddresses"`
+	Metadata    Metadata     `graphql:"metadata" json:"metadata"`
+	Ports       Ports        `graphql:"ports" json:"ports"`
+}
+
 // GetLoadBalancer is a struct that represents the GetLoadBalancer GraphQL query
 type GetLoadBalancer struct {
 	LoadBalancer LoadBalancer `graphql:"loadBalancer(id: $id)"`
+}
+
+// GetLoadBalancerHistory is a struct that represents the GetLoadBalancer GraphQL query
+type GetLoadBalancerHistory struct {
+	LoadBalancerHistory LoadBalancerHistory `graphql:"loadBalancerHistory(id: $id)"`
 }
 
 // IPAddress is a struct that represents the IPAddress GraphQL type


### PR DESCRIPTION
This adds `GetLoadBalancerHistory` to the LB client so that users of the client can easily lookup soft deleted records


**TODO:**
- Needs tests
- Need to add the following to the client to test the full lifecycle
    - CreateLoadBalancer
    - DeleteLoadBalancer