### PR TITLE
Dynamically Create Permission Relationships From Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,4 @@ coverage.txt
 .vscode
 
 # binary
-load-balancer-api
+/load-balancer-api

--- a/chart/load-balancer-api/templates/deployment.yaml
+++ b/chart/load-balancer-api/templates/deployment.yaml
@@ -144,5 +144,5 @@ spec:
         {{- end }}
         - name: config-volume
           configMap:
-            name: {{ include "common.names.fullname" . }}-additional-config
+            name: {{ include "common.names.fullname" . }}-extra-config
 

--- a/chart/load-balancer-api/templates/deployment.yaml
+++ b/chart/load-balancer-api/templates/deployment.yaml
@@ -91,6 +91,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - serve
+            - "--config=/config/loadbalancerapi.yaml"
           ports:
             - name: http
               containerPort: {{ .Values.api.listenPort | default "8080" }}
@@ -113,6 +114,9 @@ spec:
               mountPath: "/dbcerts"
               readOnly: true
             {{- end }}
+            - name: config-volume
+              mountPath: "/config"
+              readOnly: true
           resources:
             {{- toYaml .Values.api.resources | nindent 12 }}
       {{- with .Values.api.nodeSelector }}
@@ -138,3 +142,7 @@ spec:
           secret:
             secretName: "{{ .Values.api.db.certSecret }}"
         {{- end }}
+        - name: config-volume
+          configMap:
+            name: {{ include "common.names.fullname" . }}-additional-config
+

--- a/chart/load-balancer-api/templates/extra-config.yaml
+++ b/chart/load-balancer-api/templates/extra-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}-extra-config
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+data:
+  loadbalancerapi.yaml: |
+    {{- with .Values.api.extraRelations  }}
+    extraRelations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}

--- a/chart/load-balancer-api/values.yaml
+++ b/chart/load-balancer-api/values.yaml
@@ -36,6 +36,10 @@ api:
   extraAnnotations: {}
   extraEnvFrom: {}
   extraEnvVars: []
+  extraRelations: {}
+    # loadbalancer:
+    #   - relation: relationship
+    #     subjectID: subjct-1234567
   #- value: "postgresql://user@my-db-server:26257/load_balancer_api"
   #  name: LOADBALANCERAPI_CRDB_URI
   resources: {}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -117,6 +117,9 @@ func serve(ctx context.Context) error {
 	var resolverOpts []graphapi.Option
 
 	config.AppConfig.LoadBalancerLimit = viper.GetInt("load-balancer-limit")
+	if err := viper.UnmarshalKey("extraRelations", &config.AppConfig.ExtraPermissionRelations); err != nil {
+		logger.Fatalw("error unmarshaling extraRelations from config", "error", err)
+	}
 
 	if serveDevMode {
 		enablePlayground = true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,18 +17,19 @@ import (
 
 // AppConfig stores all the config values for our application
 var AppConfig struct {
-	OIDC              echojwtx.AuthConfig `mapstructure:"oidc"`
-	OIDCClient        OIDCClientConfig    `mapstructure:"oidc"`
-	CRDB              crdbx.Config
-	Logging           loggingx.Config
-	Server            echox.Config
-	Tracing           otelx.Config
-	Events            events.Config
-	Permissions       permissions.Config
-	LoadBalancerLimit int
-	Metadata          MetadataConfig
-	RestrictedPorts   []int
-	Supergraph        SupergraphConfig
+	OIDC                     echojwtx.AuthConfig `mapstructure:"oidc"`
+	OIDCClient               OIDCClientConfig    `mapstructure:"oidc"`
+	CRDB                     crdbx.Config
+	Logging                  loggingx.Config
+	Server                   echox.Config
+	Tracing                  otelx.Config
+	Events                   events.Config
+	Permissions              permissions.Config
+	LoadBalancerLimit        int
+	Metadata                 MetadataConfig
+	RestrictedPorts          []int
+	Supergraph               SupergraphConfig
+	ExtraPermissionRelations map[string][]PermissionRelation
 }
 
 // MetadataConfig stores the configuration for metadata
@@ -45,4 +46,10 @@ type SupergraphConfig struct {
 // OIDCClientConfig stores the configuration for an OIDC client
 type OIDCClientConfig struct {
 	Config oauth2x.Config `mapstructure:"client"`
+}
+
+// PermissionRelation stores the permission relation metadata needed to create AuthRelationshipRelation
+type PermissionRelation struct {
+	Relation  string
+	SubjectID string
 }

--- a/internal/manualhooks/hooks.go
+++ b/internal/manualhooks/hooks.go
@@ -11,6 +11,7 @@ import (
 	"go.infratographer.com/x/gidx"
 	"golang.org/x/exp/slices"
 
+	"go.infratographer.com/load-balancer-api/internal/config"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/hook"
 	"go.infratographer.com/load-balancer-api/internal/ent/generated/loadbalancer"
@@ -120,6 +121,16 @@ func LoadBalancerHooks() []ent.Hook {
 					Relation:  "owner",
 					SubjectID: owner_id,
 				})
+
+				// Add extra relationships based on config
+				if permissions, ok := config.AppConfig.ExtraPermissionRelations["loadbalancer"]; ok {
+					for _, p := range permissions {
+						relationships = append(relationships, events.AuthRelationshipRelation{
+							Relation:  p.Relation,
+							SubjectID: gidx.PrefixedID(p.SubjectID),
+						})
+					}
+				}
 
 				if ok {
 					cv_owner_id = fmt.Sprintf("%s", fmt.Sprint(owner_id))


### PR DESCRIPTION
# Summary of Changes

1. Adds extra config that mounts config file onto deployment to be used with `--config` flag
2. Adds ability to add permissions relationships to load balancers from new config file

Currently load balancers are created with a owner relationship with the `owner id` passed by the caller of the api, there is a need to have additional relationships that could be used for things like core services to manage load balancers without having to auth as the original passed in `owner id`.

The new config mounting allows users to put in more complex configs (other than `key:value`), in this case a map of lists of structs.

# Testing

1. Tested k8s config is created properly, then mounted properly, and finally parsed by viper properly by spinning up a test load-balancer-api app using new changes.
2. Tested creation of load balancer and to see if permissions are created in test environment.
3. Tested updating a load balancer and checked if permissions or anything else became out of the ordinary. 
4. Also tested empty config