### PR TITLE
Get Loadbalancers By Location Client Query

### DIFF
--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -22,4 +22,7 @@ var (
 
 	// ErrMetadataStatusNotFound returned when the status data is invalid
 	ErrMetadataStatusNotFound = errors.New("metadata status not found")
+
+	// ErrLocationNotFound returned when the status data is invalid
+	ErrLocationNotFound = errors.New("location not found")
 )

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -170,3 +170,16 @@ type GetMetadataNode struct {
 // 		}
 // 	} `graphql:"loadBalancer(id: $id)"`
 // }
+
+// GetLoadBalancersByLocation is a struct that represents the GetLoadBalancer GraphQL query
+type GetLoadBalancersByLocation struct {
+	Location struct {
+		LoadBalancers struct {
+			Edges []struct {
+				Node struct {
+					ID string `graphql:"id"`
+				} `graphql:"node"`
+			} `graphql:"edges"`
+		} `graphql:"loadBalancers"`
+	} `graphql:"location(id: $id)"`
+}


### PR DESCRIPTION
# Summary of Changes

This change creates the client query to get a location's load balancers.
